### PR TITLE
Allowing e to act as expand for !cases

### DIFF
--- a/src/plugins/ModActions.ts
+++ b/src/plugins/ModActions.ts
@@ -1144,7 +1144,7 @@ export class ModActionsPlugin extends ZeppelinPlugin<IModActionsPluginConfig, IM
       const showHidden = args.opts && args.opts.match(/\bhidden\b/);
       const casesToDisplay = showHidden ? cases : normalCases;
 
-      if (args.opts && (args.opts.match(/\bexpand\b/) || args.opts.match(/\be\b/)) {
+      if (args.opts && (args.opts.match(/\bexpand\b/) || args.opts.match(/\be\b/))) {
         if (casesToDisplay.length > 8) {
           msg.channel.createMessage("Too many cases for expanded view. Please use compact view instead.");
           return;

--- a/src/plugins/ModActions.ts
+++ b/src/plugins/ModActions.ts
@@ -1144,7 +1144,7 @@ export class ModActionsPlugin extends ZeppelinPlugin<IModActionsPluginConfig, IM
       const showHidden = args.opts && args.opts.match(/\bhidden\b/);
       const casesToDisplay = showHidden ? cases : normalCases;
 
-      if (args.opts && args.opts.match(/\bexpand\b/)) {
+      if (args.opts && (args.opts.match(/\bexpand\b/) || args.opts.match(/\be\b/)) {
         if (casesToDisplay.length > 8) {
           msg.channel.createMessage("Too many cases for expanded view. Please use compact view instead.");
           return;


### PR DESCRIPTION
As stated in commit [ff6812c](https://github.com/Dragory/ZeppelinBot/commit/ff6812cc4e365089fb63af93e1b32a356bf9fb19)
I think allowing e to expand would speed things up a bit. I am also getting annoyed at having to type it out every time