### PR TITLE
Fix leading white-space resulting in no results

### DIFF
--- a/src/plugins/Utility.ts
+++ b/src/plugins/Utility.ts
@@ -287,7 +287,7 @@ export class UtilityPlugin extends ZeppelinPlugin<IUtilityPluginConfig> {
     }
 
     if (args.query) {
-      const query = args["case-sensitive"] ? args.query : args.query.toLowerCase();
+      const query = args["case-sensitive"] ? args.query.trimStart() : args.query.toLowerCase().trimStart();
 
       matchingMembers = matchingMembers.filter(member => {
         const nick = args["case-sensitive"] ? member.nick : member.nick && member.nick.toLowerCase();


### PR DESCRIPTION
This should in theory make !search ignore leading white spaces that cause no results to be found since it is taken into the equation.
I might have missed a spot but i am pretty sure this is the only place where we work with the search query