### PR TITLE
fixed search case sensitivity issue

### DIFF
--- a/backend/src/plugins/Utility.ts
+++ b/backend/src/plugins/Utility.ts
@@ -341,9 +341,9 @@ export class UtilityPlugin extends ZeppelinPlugin<TConfigSchema> {
     if (args.query) {
       let queryRegex: RegExp;
       if (args.regex) {
-        queryRegex = new RegExp(args.query.trimStart(), args["case-sensitive"] ? "i" : "");
+        queryRegex = new RegExp(args.query.trimStart(), args["case-sensitive"] ? "" : "i");
       } else {
-        queryRegex = new RegExp(escapeStringRegexp(args.query.trimStart()), args["case-sensitive"] ? "i" : "");
+        queryRegex = new RegExp(escapeStringRegexp(args.query.trimStart()), args["case-sensitive"] ? "" : "i");
       }
 
       if (!safeRegex(queryRegex)) {


### PR DESCRIPTION
Since -i means 'ignore case', the current code flips the meaning of the "case-sensitive" arg. A 'true' value would make the search case insensitive, while a false or undefined value (default) would make the search case sensitive. This PR reverses the ternary statement to be in the right order