### PR TITLE
utility: add aliases for clean command

### DIFF
--- a/backend/src/plugins/Utility.ts
+++ b/backend/src/plugins/Utility.ts
@@ -728,7 +728,7 @@ export class UtilityPlugin extends ZeppelinPlugin<TConfigSchema> {
   }
 
   @d.command("clean", "<count:number>", {
-    aliases: ["purge"],
+    aliases: ["purge", "prune"],
     options: [
       {
         name: "user",

--- a/backend/src/plugins/Utility.ts
+++ b/backend/src/plugins/Utility.ts
@@ -728,6 +728,7 @@ export class UtilityPlugin extends ZeppelinPlugin<TConfigSchema> {
   }
 
   @d.command("clean", "<count:number>", {
+    aliases: ["purge"],
     options: [
       {
         name: "user",


### PR DESCRIPTION
This pull requests add the aliases "purge" and "prune" to the clean command in the utility plugin. 