### PR TITLE
Change amount of nicknames stored to the intended 10

### DIFF
--- a/backend/src/data/GuildNicknameHistory.ts
+++ b/backend/src/data/GuildNicknameHistory.ts
@@ -2,7 +2,6 @@ import { BaseGuildRepository } from "./BaseGuildRepository";
 import { getRepository, In, Repository } from "typeorm";
 import { NicknameHistoryEntry } from "./entities/NicknameHistoryEntry";
 import { MINUTES, SECONDS, sorter } from "../utils";
-import { MAX_USERNAME_ENTRIES_PER_USER } from "./UsernameHistory";
 import { isAPI } from "../globals";
 import { cleanupNicknames } from "./cleanup/nicknames";
 
@@ -65,7 +64,7 @@ export class GuildNicknameHistory extends BaseGuildRepository {
       .where("guild_id = :guildId", { guildId: this.guildId })
       .andWhere("user_id = :userId", { userId })
       .orderBy("id", "DESC")
-      .skip(MAX_USERNAME_ENTRIES_PER_USER)
+      .skip(MAX_NICKNAME_ENTRIES_PER_USER)
       .take(99_999)
       .getMany();
 


### PR DESCRIPTION
Changed to the intended variable that allows 10 stored nicknames, as per https://canary.discordapp.com/channels/473085256233123841/534711120393404426/717898336090456106