### PR TITLE
Fix failed DM welcome messages sending the log undefined#undefined

### DIFF
--- a/backend/src/plugins/WelcomeMessage/events/SendWelcomeMessageEvt.ts
+++ b/backend/src/plugins/WelcomeMessage/events/SendWelcomeMessageEvt.ts
@@ -28,7 +28,7 @@ export const SendWelcomeMessageEvt = welcomeEvent({
       } catch (e) {
         pluginData.state.logs.log(LogType.BOT_ALERT, {
           body: `Failed send a welcome DM to {userMention(member)}`,
-          member: stripObjectToScalars(member),
+          member: stripObjectToScalars(member, ["user"]),
         });
       }
     }


### PR DESCRIPTION
![1860-DiscordCanary-1596322210](https://user-images.githubusercontent.com/7890309/89111785-23bdae00-d45a-11ea-9f2b-e38bda9b03e0.png)
