### PR TITLE
Feature: Adding modlogs as an alias to the cases commands

### DIFF
--- a/backend/src/plugins/ModActions/commands/CasesModCmd.ts
+++ b/backend/src/plugins/ModActions/commands/CasesModCmd.ts
@@ -14,7 +14,7 @@ const opts = {
 };
 
 export const CasesModCmd = modActionsCmd({
-  trigger: "cases",
+  trigger: ["cases", "modlogs"],
   permission: "can_view",
   description: "Show the most recent 5 cases by the specified -mod",
 

--- a/backend/src/plugins/ModActions/commands/CasesUserCmd.ts
+++ b/backend/src/plugins/ModActions/commands/CasesUserCmd.ts
@@ -22,7 +22,7 @@ const opts = {
 };
 
 export const CasesUserCmd = modActionsCmd({
-  trigger: "cases",
+  trigger: ["cases", "modlogs"],
   permission: "can_view",
   description: "Show a list of cases the specified user has",
 


### PR DESCRIPTION
Wanted to add !modlogs as an alias to !cases because I've been getting a lot of requests for that