### PR TITLE
Allow automatic tag invoke deletion

### DIFF
--- a/backend/src/plugins/Tags/TagsPlugin.ts
+++ b/backend/src/plugins/Tags/TagsPlugin.ts
@@ -30,7 +30,7 @@ const defaultOptions: PluginOptions<TagsPluginType> = {
     global_tag_cooldown: null,
     user_cooldown: null,
     global_cooldown: null,
-    global_delete_invoke: false,
+    auto_delete_command: false,
 
     categories: {},
 
@@ -74,7 +74,7 @@ export const TagsPlugin = zeppelinGuildPlugin<TagsPluginType>()("tags", {
   },
 
   configPreprocessor(options) {
-    if (options.config.delete_with_command && options.config.global_delete_invoke) {
+    if (options.config.delete_with_command && options.config.auto_delete_command) {
       throw new StrictValidationError([
         `Cannot have both (global) delete_with_command and global_delete_invoke enabled`,
       ]);
@@ -84,7 +84,7 @@ export const TagsPlugin = zeppelinGuildPlugin<TagsPluginType>()("tags", {
     if (options.config?.categories) {
       for (const [name, opts] of Object.entries(options.config.categories)) {
         const cat = options.config.categories[name];
-        if (cat.delete_with_command && cat.category_delete_invoke) {
+        if (cat.delete_with_command && cat.auto_delete_command) {
           throw new StrictValidationError([
             `Cannot have both (category specific) delete_with_command and category_delete_invoke enabled at <categories/${name}>`,
           ]);

--- a/backend/src/plugins/Tags/TagsPlugin.ts
+++ b/backend/src/plugins/Tags/TagsPlugin.ts
@@ -19,6 +19,7 @@ import { TimeAndDatePlugin } from "../TimeAndDate/TimeAndDatePlugin";
 import { mapToPublicFn } from "../../pluginUtils";
 import { renderTagBody } from "./util/renderTagBody";
 import { findTagByName } from "./util/findTagByName";
+import { StrictValidationError } from "src/validatorUtils";
 
 const defaultOptions: PluginOptions<TagsPluginType> = {
   config: {
@@ -29,6 +30,7 @@ const defaultOptions: PluginOptions<TagsPluginType> = {
     global_tag_cooldown: null,
     user_cooldown: null,
     global_cooldown: null,
+    global_delete_invoke: false,
 
     categories: {},
 
@@ -69,6 +71,28 @@ export const TagsPlugin = zeppelinGuildPlugin<TagsPluginType>()("tags", {
   public: {
     renderTagBody: mapToPublicFn(renderTagBody),
     findTagByName: mapToPublicFn(findTagByName),
+  },
+
+  configPreprocessor(options) {
+    if (options.config.delete_with_command && options.config.global_delete_invoke) {
+      throw new StrictValidationError([
+        `Cannot have both (global) delete_with_command and global_delete_invoke enabled`,
+      ]);
+    }
+
+    // Check each category for conflicting options
+    if (options.config?.categories) {
+      for (const [name, opts] of Object.entries(options.config.categories)) {
+        const cat = options.config.categories[name];
+        if (cat.delete_with_command && cat.category_delete_invoke) {
+          throw new StrictValidationError([
+            `Cannot have both (category specific) delete_with_command and category_delete_invoke enabled at <categories/${name}>`,
+          ]);
+        }
+      }
+    }
+
+    return options;
   },
 
   onLoad(pluginData) {

--- a/backend/src/plugins/Tags/types.ts
+++ b/backend/src/plugins/Tags/types.ts
@@ -16,7 +16,7 @@ export const TagCategory = t.type({
   user_category_cooldown: tNullable(t.union([t.string, t.number])), // Per user, per tag category
   global_tag_cooldown: tNullable(t.union([t.string, t.number])), // Any user, per tag
   global_category_cooldown: tNullable(t.union([t.string, t.number])), // Any user, per category
-  category_delete_invoke: tNullable(t.boolean), // Any tag, per tag category
+  auto_delete_command: tNullable(t.boolean), // Any tag, per tag category
 
   tags: t.record(t.string, Tag),
 
@@ -32,7 +32,7 @@ export const ConfigSchema = t.type({
   global_tag_cooldown: tNullable(t.union([t.string, t.number])), // Any user, per tag
   user_cooldown: tNullable(t.union([t.string, t.number])), // Per user
   global_cooldown: tNullable(t.union([t.string, t.number])), // Any tag use
-  global_delete_invoke: t.boolean, // Any tag
+  auto_delete_command: t.boolean, // Any tag
 
   categories: t.record(t.string, TagCategory),
 

--- a/backend/src/plugins/Tags/types.ts
+++ b/backend/src/plugins/Tags/types.ts
@@ -16,6 +16,7 @@ export const TagCategory = t.type({
   user_category_cooldown: tNullable(t.union([t.string, t.number])), // Per user, per tag category
   global_tag_cooldown: tNullable(t.union([t.string, t.number])), // Any user, per tag
   global_category_cooldown: tNullable(t.union([t.string, t.number])), // Any user, per category
+  category_delete_invoke: tNullable(t.boolean), // Any tag, per tag category
 
   tags: t.record(t.string, Tag),
 
@@ -31,6 +32,7 @@ export const ConfigSchema = t.type({
   global_tag_cooldown: tNullable(t.union([t.string, t.number])), // Any user, per tag
   user_cooldown: tNullable(t.union([t.string, t.number])), // Per user
   global_cooldown: tNullable(t.union([t.string, t.number])), // Any tag use
+  global_delete_invoke: t.boolean, // Any tag
 
   categories: t.record(t.string, TagCategory),
 

--- a/backend/src/plugins/Tags/util/onMessageCreate.ts
+++ b/backend/src/plugins/Tags/util/onMessageCreate.ts
@@ -1,7 +1,7 @@
 import { TagsPluginType } from "../types";
 import { SavedMessage } from "../../../data/entities/SavedMessage";
 import { GuildPluginData } from "knub";
-import { convertDelayStringToMS, resolveMember, tStrictMessageContent } from "../../../utils";
+import { convertDelayStringToMS, noop, resolveMember, tStrictMessageContent } from "../../../utils";
 import { validate } from "../../../validatorUtils";
 import { LogType } from "../../../data/LogType";
 import { TextChannel } from "eris";
@@ -108,5 +108,11 @@ export async function onMessageCreate(pluginData: GuildPluginData<TagsPluginType
     pluginData.state.savedMessages.onceMessageAvailable(responseMsg.id, async () => {
       await pluginData.state.tags.addResponse(msg.id, responseMsg.id);
     });
+  }
+
+  const deleteInvoke = tagResult.category?.category_delete_invoke ?? config.global_delete_invoke;
+  if (!deleteWithCommand && deleteInvoke) {
+    // Try deleting the invoking message, ignore errors silently
+    pluginData.client.deleteMessage(msg.channel_id, msg.id).catch(noop);
   }
 }


### PR DESCRIPTION
Includes config preprocessor to only allow either `delete_with_command` or `xyz_delete_invoke`, never both (Both globally and for every category).
Falls back to `delete_with_command` in case delete_with_command is enabled in an override.