### PR TITLE
Correct mention regex in mention tag function

### DIFF
--- a/backend/src/plugins/Tags/TagsPlugin.ts
+++ b/backend/src/plugins/Tags/TagsPlugin.ts
@@ -202,7 +202,7 @@ export const TagsPlugin = zeppelinGuildPlugin<TagsPluginType>()("tags", {
           return "";
         }
 
-        if (input.match(/^<(@#)(!&)\d+>$/)) {
+        if (input.match(/^<(?:@(?:!|&)?|#)\d+>$/)) {
           return input;
         }
 


### PR DESCRIPTION
Previously wouldn't match mentions, but would match `<@#!&[id]>`. Now matches mentions (user, role, or channel) correctly.