### PR TITLE
Allow kicking the user from VC on mute

### DIFF
--- a/backend/src/plugins/Mutes/MutesPlugin.ts
+++ b/backend/src/plugins/Mutes/MutesPlugin.ts
@@ -23,6 +23,7 @@ const defaultOptions = {
   config: {
     mute_role: null,
     move_to_voice_channel: null,
+    kick_from_voice_channel: false,
 
     dm_on_mute: false,
     dm_on_update: false,

--- a/backend/src/plugins/Mutes/functions/muteUser.ts
+++ b/backend/src/plugins/Mutes/functions/muteUser.ts
@@ -89,9 +89,10 @@ export async function muteUser(
     }
 
     // If enabled, move the user to the mute voice channel (e.g. afk - just to apply the voice perms from the mute role)
-    const moveToVoiceChannelId = pluginData.config.get().move_to_voice_channel;
+    let moveToVoiceChannelId = pluginData.config.get().move_to_voice_channel;
     if (moveToVoiceChannelId) {
       // TODO: Add back the voiceState check once we figure out how to get voice state for guild members that are loaded on-demand
+      if (moveToVoiceChannelId.match(".*[^0-9].*")) moveToVoiceChannelId = null;
       try {
         await member.edit({ channelID: moveToVoiceChannelId });
       } catch (e) {} // tslint:disable-line

--- a/backend/src/plugins/Mutes/functions/muteUser.ts
+++ b/backend/src/plugins/Mutes/functions/muteUser.ts
@@ -89,12 +89,12 @@ export async function muteUser(
     }
 
     // If enabled, move the user to the mute voice channel (e.g. afk - just to apply the voice perms from the mute role)
-    let moveToVoiceChannelId = pluginData.config.get().move_to_voice_channel;
-    if (moveToVoiceChannelId) {
+    const cfg = pluginData.config.get();
+    const moveToVoiceChannel = cfg.kick_from_voice_channel ? null : cfg.move_to_voice_channel;
+    if (moveToVoiceChannel || cfg.kick_from_voice_channel) {
       // TODO: Add back the voiceState check once we figure out how to get voice state for guild members that are loaded on-demand
-      if (moveToVoiceChannelId.match(".*[^0-9].*")) moveToVoiceChannelId = null;
       try {
-        await member.edit({ channelID: moveToVoiceChannelId });
+        await member.edit({ channelID: moveToVoiceChannel });
       } catch (e) {} // tslint:disable-line
     }
   }

--- a/backend/src/plugins/Mutes/types.ts
+++ b/backend/src/plugins/Mutes/types.ts
@@ -14,6 +14,7 @@ import Timeout = NodeJS.Timeout;
 export const ConfigSchema = t.type({
   mute_role: tNullable(t.string),
   move_to_voice_channel: tNullable(t.string),
+  kick_from_voice_channel: t.boolean,
 
   dm_on_mute: t.boolean,
   dm_on_update: t.boolean,


### PR DESCRIPTION
If any non-id string is entered in `move_to_voice_channel`, the user is kicked from the VC instead of being moved. We do not automatically kick if the option is set to null in order to not make this a breaking change for old, intended behavior