### PR TITLE
Add allow_mentions option to enable tags mentioning users and roles

### DIFF
--- a/backend/src/plugins/Tags/TagsPlugin.ts
+++ b/backend/src/plugins/Tags/TagsPlugin.ts
@@ -29,6 +29,7 @@ const defaultOptions: PluginOptions<TagsPluginType> = {
     user_tag_cooldown: null,
     global_tag_cooldown: null,
     user_cooldown: null,
+    allow_mentions: false,
     global_cooldown: null,
     auto_delete_command: false,
 

--- a/backend/src/plugins/Tags/types.ts
+++ b/backend/src/plugins/Tags/types.ts
@@ -15,6 +15,7 @@ export const TagCategory = t.type({
   user_tag_cooldown: tNullable(t.union([t.string, t.number])), // Per user, per tag
   user_category_cooldown: tNullable(t.union([t.string, t.number])), // Per user, per tag category
   global_tag_cooldown: tNullable(t.union([t.string, t.number])), // Any user, per tag
+  allow_mentions: tNullable(t.boolean), // Per user, per category
   global_category_cooldown: tNullable(t.union([t.string, t.number])), // Any user, per category
   auto_delete_command: tNullable(t.boolean), // Any tag, per tag category
 
@@ -31,6 +32,7 @@ export const ConfigSchema = t.type({
   user_tag_cooldown: tNullable(t.union([t.string, t.number])), // Per user, per tag
   global_tag_cooldown: tNullable(t.union([t.string, t.number])), // Any user, per tag
   user_cooldown: tNullable(t.union([t.string, t.number])), // Per user
+  allow_mentions: t.boolean, // Per user
   global_cooldown: tNullable(t.union([t.string, t.number])), // Any tag use
   auto_delete_command: t.boolean, // Any tag
 

--- a/backend/src/plugins/Tags/util/onMessageCreate.ts
+++ b/backend/src/plugins/Tags/util/onMessageCreate.ts
@@ -99,7 +99,11 @@ export async function onMessageCreate(pluginData: GuildPluginData<TagsPluginType
     return;
   }
 
-  const responseMsg = await channel.createMessage(tagResult.renderedContent);
+  const allowMentions = tagResult.category?.allow_mentions ?? config.allow_mentions;
+  const responseMsg = await channel.createMessage({
+    ...tagResult.renderedContent,
+    allowedMentions: { roles: allowMentions, users: allowMentions },
+  });
 
   // Save the command-response message pair once the message is in our database
   const deleteWithCommand = tagResult.category?.delete_with_command ?? config.delete_with_command;


### PR DESCRIPTION
Checked when a tag is posted - so a tag can have for example pings enabled if a mod executes that tag, but not if anyone below mod does it.