### PR TITLE
Allow filtering !cases to certain types using switches

### DIFF
--- a/backend/src/plugins/ModActions/commands/CasesUserCmd.ts
+++ b/backend/src/plugins/ModActions/commands/CasesUserCmd.ts
@@ -21,12 +21,12 @@ const opts = {
   expand: ct.bool({ option: true, isSwitch: true, shortcut: "e" }),
   hidden: ct.bool({ option: true, isSwitch: true, shortcut: "h" }),
   reverseFilters: ct.switchOption({ shortcut: "r" }),
-  onlyNotes: ct.switchOption({ shortcut: "n" }),
-  onlyWarns: ct.switchOption({ shortcut: "w" }),
-  onlyMutes: ct.switchOption({ shortcut: "m" }),
-  onyUnmutes: ct.switchOption({ shortcut: "um" }),
-  onlyBans: ct.switchOption({ shortcut: "b" }),
-  onyUnbans: ct.switchOption({ shortcut: "ub" }),
+  notes: ct.switchOption({ shortcut: "n" }),
+  warns: ct.switchOption({ shortcut: "w" }),
+  mutes: ct.switchOption({ shortcut: "m" }),
+  unmutes: ct.switchOption({ shortcut: "um" }),
+  bans: ct.switchOption({ shortcut: "b" }),
+  unbans: ct.switchOption({ shortcut: "ub" }),
 };
 
 export const CasesUserCmd = modActionsCmd({
@@ -52,12 +52,12 @@ export const CasesUserCmd = modActionsCmd({
     let cases = await pluginData.state.cases.with("notes").getByUserId(user.id);
 
     const typesToShow: CaseTypes[] = [];
-    if (args.onlyNotes) typesToShow.push(CaseTypes.Note);
-    if (args.onlyWarns) typesToShow.push(CaseTypes.Warn);
-    if (args.onlyMutes) typesToShow.push(CaseTypes.Mute);
-    if (args.onyUnmutes) typesToShow.push(CaseTypes.Unmute);
-    if (args.onlyBans) typesToShow.push(CaseTypes.Ban);
-    if (args.onyUnbans) typesToShow.push(CaseTypes.Unban);
+    if (args.notes) typesToShow.push(CaseTypes.Note);
+    if (args.warns) typesToShow.push(CaseTypes.Warn);
+    if (args.mutes) typesToShow.push(CaseTypes.Mute);
+    if (args.unmutes) typesToShow.push(CaseTypes.Unmute);
+    if (args.bans) typesToShow.push(CaseTypes.Ban);
+    if (args.unbans) typesToShow.push(CaseTypes.Unban);
 
     if (typesToShow.length > 0) {
       // Reversed: Hide specified types

--- a/backend/src/plugins/ModActions/commands/CasesUserCmd.ts
+++ b/backend/src/plugins/ModActions/commands/CasesUserCmd.ts
@@ -15,10 +15,17 @@ import { getGuildPrefix } from "../../../utils/getGuildPrefix";
 import { EmbedOptions, User } from "eris";
 import { getChunkedEmbedFields } from "../../../utils/getChunkedEmbedFields";
 import { asyncMap } from "../../../utils/async";
+import { CaseTypes } from "../../../data/CaseTypes";
 
 const opts = {
   expand: ct.bool({ option: true, isSwitch: true, shortcut: "e" }),
   hidden: ct.bool({ option: true, isSwitch: true, shortcut: "h" }),
+  onlyNotes: ct.switchOption({ shortcut: "n" }),
+  onlyWarns: ct.switchOption({ shortcut: "w" }),
+  onlyMutes: ct.switchOption({ shortcut: "m" }),
+  onyUnmutes: ct.switchOption({ shortcut: "um" }),
+  onlyBans: ct.switchOption({ shortcut: "b" }),
+  onyUnbans: ct.switchOption({ shortcut: "ub" }),
 };
 
 export const CasesUserCmd = modActionsCmd({
@@ -41,7 +48,17 @@ export const CasesUserCmd = modActionsCmd({
       return;
     }
 
-    const cases = await pluginData.state.cases.with("notes").getByUserId(user.id);
+    let cases = await pluginData.state.cases.with("notes").getByUserId(user.id);
+
+    const typesToShow: CaseTypes[] = [];
+    if (args.onlyNotes) typesToShow.push(CaseTypes.Note);
+    if (args.onlyWarns) typesToShow.push(CaseTypes.Warn);
+    if (args.onlyMutes) typesToShow.push(CaseTypes.Mute);
+    if (args.onyUnmutes) typesToShow.push(CaseTypes.Unmute);
+    if (args.onlyBans) typesToShow.push(CaseTypes.Ban);
+    if (args.onyUnbans) typesToShow.push(CaseTypes.Unban);
+    if (typesToShow.length > 0) cases = cases.filter(c => typesToShow.includes(c.type));
+
     const normalCases = cases.filter(c => !c.is_hidden);
     const hiddenCases = cases.filter(c => c.is_hidden);
 

--- a/backend/src/plugins/ModActions/commands/CasesUserCmd.ts
+++ b/backend/src/plugins/ModActions/commands/CasesUserCmd.ts
@@ -60,9 +60,10 @@ export const CasesUserCmd = modActionsCmd({
     if (args.onyUnbans) typesToShow.push(CaseTypes.Unban);
 
     if (typesToShow.length > 0) {
-      if (args.reverseFilters) cases = cases.filter(c => !typesToShow.includes(c.type));
       // Reversed: Hide specified types
-      else cases = cases.filter(c => typesToShow.includes(c.type)); // Normal: Show only specified types
+      if (args.reverseFilters) cases = cases.filter(c => !typesToShow.includes(c.type));
+      // Normal: Show only specified types
+      else cases = cases.filter(c => typesToShow.includes(c.type));
     }
 
     const normalCases = cases.filter(c => !c.is_hidden);

--- a/backend/src/plugins/ModActions/commands/CasesUserCmd.ts
+++ b/backend/src/plugins/ModActions/commands/CasesUserCmd.ts
@@ -20,6 +20,7 @@ import { CaseTypes } from "../../../data/CaseTypes";
 const opts = {
   expand: ct.bool({ option: true, isSwitch: true, shortcut: "e" }),
   hidden: ct.bool({ option: true, isSwitch: true, shortcut: "h" }),
+  reverseFilters: ct.switchOption({ shortcut: "r" }),
   onlyNotes: ct.switchOption({ shortcut: "n" }),
   onlyWarns: ct.switchOption({ shortcut: "w" }),
   onlyMutes: ct.switchOption({ shortcut: "m" }),
@@ -57,7 +58,12 @@ export const CasesUserCmd = modActionsCmd({
     if (args.onyUnmutes) typesToShow.push(CaseTypes.Unmute);
     if (args.onlyBans) typesToShow.push(CaseTypes.Ban);
     if (args.onyUnbans) typesToShow.push(CaseTypes.Unban);
-    if (typesToShow.length > 0) cases = cases.filter(c => typesToShow.includes(c.type));
+
+    if (typesToShow.length > 0) {
+      if (args.reverseFilters) cases = cases.filter(c => !typesToShow.includes(c.type));
+      // Reversed: Hide specified types
+      else cases = cases.filter(c => typesToShow.includes(c.type)); // Normal: Show only specified types
+    }
 
     const normalCases = cases.filter(c => !c.is_hidden);
     const hiddenCases = cases.filter(c => c.is_hidden);


### PR DESCRIPTION
It is also possible to reverse the filters using the -r flag.
Examples:

`!cases 108552944961454080 -m -b` Only shows mutes and bans
`!cases 108552944961454080 -r -m` Shows all types *except* for mutes