### PR TITLE
chore: improve wording on permissions error for -mod

### DIFF
--- a/backend/src/plugins/ModActions/commands/AddCaseCmd.ts
+++ b/backend/src/plugins/ModActions/commands/AddCaseCmd.ts
@@ -45,7 +45,7 @@ export const AddCaseCmd = modActionsCmd({
     let mod = msg.member;
     if (args.mod) {
       if (!hasPermission(pluginData, "can_act_as_other", { message: msg })) {
-        sendErrorMessage(pluginData, msg.channel, "No permission for -mod");
+        sendErrorMessage(pluginData, msg.channel, "You don't have permission to use -mod");
         return;
       }
 

--- a/backend/src/plugins/ModActions/commands/BanCmd.ts
+++ b/backend/src/plugins/ModActions/commands/BanCmd.ts
@@ -54,7 +54,7 @@ export const BanCmd = modActionsCmd({
     let mod = msg.member;
     if (args.mod) {
       if (!hasPermission(pluginData, "can_act_as_other", { message: msg, channelId: msg.channel.id })) {
-        sendErrorMessage(pluginData, msg.channel, "No permission for -mod");
+        sendErrorMessage(pluginData, msg.channel, "You don't have permission to use -mod");
         return;
       }
 

--- a/backend/src/plugins/ModActions/commands/ForcebanCmd.ts
+++ b/backend/src/plugins/ModActions/commands/ForcebanCmd.ts
@@ -54,7 +54,7 @@ export const ForcebanCmd = modActionsCmd({
     let mod = msg.member;
     if (args.mod) {
       if (!hasPermission(pluginData, "can_act_as_other", { message: msg })) {
-        sendErrorMessage(pluginData, msg.channel, "No permission for -mod");
+        sendErrorMessage(pluginData, msg.channel, "You don't have permission to use -mod");
         return;
       }
 

--- a/backend/src/plugins/ModActions/commands/UnbanCmd.ts
+++ b/backend/src/plugins/ModActions/commands/UnbanCmd.ts
@@ -37,7 +37,7 @@ export const UnbanCmd = modActionsCmd({
     let mod = msg.member;
     if (args.mod) {
       if (!hasPermission(pluginData, "can_act_as_other", { message: msg, channelId: msg.channel.id })) {
-        sendErrorMessage(pluginData, msg.channel, "No permission for -mod");
+        sendErrorMessage(pluginData, msg.channel, "You don't have permission to use -mod");
         return;
       }
 

--- a/backend/src/plugins/ModActions/commands/WarnCmd.ts
+++ b/backend/src/plugins/ModActions/commands/WarnCmd.ts
@@ -57,7 +57,7 @@ export const WarnCmd = modActionsCmd({
     let mod = msg.member;
     if (args.mod) {
       if (!hasPermission(pluginData, "can_act_as_other", { message: msg })) {
-        msg.channel.createMessage(errorMessage("No permission for -mod"));
+        msg.channel.createMessage(errorMessage("You don't have permission to use -mod"));
         return;
       }
 

--- a/backend/src/plugins/ModActions/functions/actualKickMemberCmd.ts
+++ b/backend/src/plugins/ModActions/functions/actualKickMemberCmd.ts
@@ -52,7 +52,7 @@ export async function actualKickMemberCmd(
   let mod = msg.member;
   if (args.mod) {
     if (!hasPermission(pluginData.config.getForMessage(msg), "can_act_as_other")) {
-      sendErrorMessage(pluginData, msg.channel, "No permission for -mod");
+      sendErrorMessage(pluginData, msg.channel, "You don't have permission to use -mod");
       return;
     }
 

--- a/backend/src/plugins/ModActions/functions/actualMuteUserCmd.ts
+++ b/backend/src/plugins/ModActions/functions/actualMuteUserCmd.ts
@@ -28,7 +28,7 @@ export async function actualMuteUserCmd(
 
   if (args.mod) {
     if (!hasPermission(pluginData, "can_act_as_other", { message: msg })) {
-      sendErrorMessage(pluginData, msg.channel, "No permission for -mod");
+      sendErrorMessage(pluginData, msg.channel, "You don't have permission to use -mod");
       return;
     }
 

--- a/backend/src/plugins/ModActions/functions/actualUnmuteUserCmd.ts
+++ b/backend/src/plugins/ModActions/functions/actualUnmuteUserCmd.ts
@@ -19,7 +19,7 @@ export async function actualUnmuteCmd(
 
   if (args.mod) {
     if (!hasPermission(pluginData, "can_act_as_other", { message: msg, channelId: msg.channel.id })) {
-      sendErrorMessage(pluginData, msg.channel, "No permission for -mod");
+      sendErrorMessage(pluginData, msg.channel, "You don't have permission to use -mod");
       return;
     }
 

--- a/backend/src/plugins/Starboard/StarboardPlugin.ts
+++ b/backend/src/plugins/Starboard/StarboardPlugin.ts
@@ -57,6 +57,19 @@ export const StarboardPlugin = zeppelinGuildPlugin<StarboardPluginType>()("starb
               stars_required: 5
       ~~~
       
+      ### Basic starboard with custom color
+      Any message on the server that gets 5 star reactions will be posted into the starboard channel (604342689038729226), with the given color (0x87CEEB).
+      
+      ~~~yml
+      starboard:
+        config:
+          boards:
+            basic:
+              channel_id: "604342689038729226"
+              stars_required: 5
+              color: 0x87CEEB
+      ~~~
+      
       ### Custom star emoji
       This is identical to the basic starboard above, but accepts two emoji: the regular star and a custom :mrvnSmile: emoji
       

--- a/backend/src/plugins/Starboard/types.ts
+++ b/backend/src/plugins/Starboard/types.ts
@@ -12,6 +12,7 @@ const StarboardOpts = t.type({
   copy_full_embed: tNullable(t.boolean),
   enabled: tNullable(t.boolean),
   show_star_count: t.boolean,
+  color: t.number,
 });
 export type TStarboardOpts = t.TypeOf<typeof StarboardOpts>;
 
@@ -27,6 +28,7 @@ export const defaultStarboardOpts: Partial<TStarboardOpts> = {
   star_emoji: ["⭐"],
   enabled: true,
   show_star_count: true,
+  color: 0,
 };
 
 export interface StarboardPluginType extends BasePluginType {

--- a/backend/src/plugins/Starboard/util/createStarboardEmbedFromMessage.ts
+++ b/backend/src/plugins/Starboard/util/createStarboardEmbedFromMessage.ts
@@ -8,7 +8,7 @@ const videoAttachmentExtensions = ["mp4", "mkv", "mov"];
 
 type StarboardEmbed = EmbedWith<"footer" | "author" | "fields" | "timestamp">;
 
-export function createStarboardEmbedFromMessage(msg: Message, copyFullEmbed: boolean): StarboardEmbed {
+export function createStarboardEmbedFromMessage(msg: Message, copyFullEmbed: boolean, color: number): StarboardEmbed {
   const embed: StarboardEmbed = {
     footer: {
       text: `#${(msg.channel as GuildChannel).name}`,
@@ -18,6 +18,7 @@ export function createStarboardEmbedFromMessage(msg: Message, copyFullEmbed: boo
     },
     fields: [],
     timestamp: new Date(msg.timestamp).toISOString(),
+    color: color,
   };
 
   if (msg.author.avatarURL) {

--- a/backend/src/plugins/Starboard/util/saveMessageToStarboard.ts
+++ b/backend/src/plugins/Starboard/util/saveMessageToStarboard.ts
@@ -16,7 +16,7 @@ export async function saveMessageToStarboard(
   if (!channel) return;
 
   const starCount = (await pluginData.state.starboardReactions.getAllReactionsForMessageId(msg.id)).length;
-  const embed = createStarboardEmbedFromMessage(msg, Boolean(starboard.copy_full_embed));
+  const embed = createStarboardEmbedFromMessage(msg, Boolean(starboard.copy_full_embed), starboard.color);
   embed.fields!.push(createStarboardPseudoFooterForMessage(starboard, msg, starboard.star_emoji![0], starCount));
 
   const starboardMessage = await (channel as TextChannel).createMessage({ embed });


### PR DESCRIPTION
Previously the message was "No permission for -mod" which is a bit ambiguous, and could suggest that the bot doesn't have permission which doesn't make much sense, so I've changed it to "You don't have permission to use -mod" to better convey it's the command author who lacks the required permissions.