### PR TITLE
chore: update wording of permission error for -mod

### DIFF
--- a/backend/src/plugins/ModActions/commands/AddCaseCmd.ts
+++ b/backend/src/plugins/ModActions/commands/AddCaseCmd.ts
@@ -45,7 +45,7 @@ export const AddCaseCmd = modActionsCmd({
     let mod = msg.member;
     if (args.mod) {
       if (!hasPermission(pluginData, "can_act_as_other", { message: msg })) {
-        sendErrorMessage(pluginData, msg.channel, "No permission for -mod");
+        sendErrorMessage(pluginData, msg.channel, "You don't have permission to use -mod");
         return;
       }
 

--- a/backend/src/plugins/ModActions/commands/BanCmd.ts
+++ b/backend/src/plugins/ModActions/commands/BanCmd.ts
@@ -54,7 +54,7 @@ export const BanCmd = modActionsCmd({
     let mod = msg.member;
     if (args.mod) {
       if (!hasPermission(pluginData, "can_act_as_other", { message: msg, channelId: msg.channel.id })) {
-        sendErrorMessage(pluginData, msg.channel, "No permission for -mod");
+        sendErrorMessage(pluginData, msg.channel, "You don't have permission to use -mod");
         return;
       }
 

--- a/backend/src/plugins/ModActions/commands/ForcebanCmd.ts
+++ b/backend/src/plugins/ModActions/commands/ForcebanCmd.ts
@@ -54,7 +54,7 @@ export const ForcebanCmd = modActionsCmd({
     let mod = msg.member;
     if (args.mod) {
       if (!hasPermission(pluginData, "can_act_as_other", { message: msg })) {
-        sendErrorMessage(pluginData, msg.channel, "No permission for -mod");
+        sendErrorMessage(pluginData, msg.channel, "You don't have permission to use -mod");
         return;
       }
 

--- a/backend/src/plugins/ModActions/commands/UnbanCmd.ts
+++ b/backend/src/plugins/ModActions/commands/UnbanCmd.ts
@@ -37,7 +37,7 @@ export const UnbanCmd = modActionsCmd({
     let mod = msg.member;
     if (args.mod) {
       if (!hasPermission(pluginData, "can_act_as_other", { message: msg, channelId: msg.channel.id })) {
-        sendErrorMessage(pluginData, msg.channel, "No permission for -mod");
+        sendErrorMessage(pluginData, msg.channel, "You don't have permission to use -mod");
         return;
       }
 

--- a/backend/src/plugins/ModActions/commands/WarnCmd.ts
+++ b/backend/src/plugins/ModActions/commands/WarnCmd.ts
@@ -57,7 +57,7 @@ export const WarnCmd = modActionsCmd({
     let mod = msg.member;
     if (args.mod) {
       if (!hasPermission(pluginData, "can_act_as_other", { message: msg })) {
-        msg.channel.createMessage(errorMessage("No permission for -mod"));
+        msg.channel.createMessage(errorMessage("You don't have permission to use -mod"));
         return;
       }
 

--- a/backend/src/plugins/ModActions/functions/actualKickMemberCmd.ts
+++ b/backend/src/plugins/ModActions/functions/actualKickMemberCmd.ts
@@ -52,7 +52,7 @@ export async function actualKickMemberCmd(
   let mod = msg.member;
   if (args.mod) {
     if (!hasPermission(pluginData.config.getForMessage(msg), "can_act_as_other")) {
-      sendErrorMessage(pluginData, msg.channel, "No permission for -mod");
+      sendErrorMessage(pluginData, msg.channel, "You don't have permission to use -mod");
       return;
     }
 

--- a/backend/src/plugins/ModActions/functions/actualMuteUserCmd.ts
+++ b/backend/src/plugins/ModActions/functions/actualMuteUserCmd.ts
@@ -28,7 +28,7 @@ export async function actualMuteUserCmd(
 
   if (args.mod) {
     if (!hasPermission(pluginData, "can_act_as_other", { message: msg })) {
-      sendErrorMessage(pluginData, msg.channel, "No permission for -mod");
+      sendErrorMessage(pluginData, msg.channel, "You don't have permission to use -mod");
       return;
     }
 

--- a/backend/src/plugins/ModActions/functions/actualUnmuteUserCmd.ts
+++ b/backend/src/plugins/ModActions/functions/actualUnmuteUserCmd.ts
@@ -19,7 +19,7 @@ export async function actualUnmuteCmd(
 
   if (args.mod) {
     if (!hasPermission(pluginData, "can_act_as_other", { message: msg, channelId: msg.channel.id })) {
-      sendErrorMessage(pluginData, msg.channel, "No permission for -mod");
+      sendErrorMessage(pluginData, msg.channel, "You don't have permission to use -mod");
       return;
     }
 


### PR DESCRIPTION
Previously the message was "No permission for -mod" which is a bit ambiguous, and could suggest that the bot doesn't have permission which doesn't make much sense, so I've changed it to "You don't have permission to use -mod" to better convey it's the command author who lacks the required permissions.