### PR TITLE
added missing duration format to docs

### DIFF
--- a/dashboard/src/components/docs/ArgumentTypes.vue
+++ b/dashboard/src/components/docs/ArgumentTypes.vue
@@ -83,6 +83,9 @@
         Durations:
         <ul>
           <li>
+            <code>w</code> Week
+          </li>
+          <li>
             <code>d</code> Day
           </li>
           <li>


### PR DESCRIPTION
Weeks were missing but [are supported](https://github.com/Dragory/ZeppelinBot/blob/edd78fc9c643a4ba92a21ffc5bd50b8b8e00e448/backend/src/utils.ts#L45)