### PR TITLE
Added role and emoji info commands

### DIFF
--- a/backend/src/plugins/Utility/UtilityPlugin.ts
+++ b/backend/src/plugins/Utility/UtilityPlugin.ts
@@ -26,7 +26,6 @@ import { ReloadGuildCmd } from "./commands/ReloadGuildCmd";
 import { JumboCmd } from "./commands/JumboCmd";
 import { AvatarCmd } from "./commands/AvatarCmd";
 import { CleanCmd } from "./commands/CleanCmd";
-import { Message } from "eris";
 import { InviteInfoCmd } from "./commands/InviteInfoCmd";
 import { ChannelInfoCmd } from "./commands/ChannelInfoCmd";
 import { MessageInfoCmd } from "./commands/MessageInfoCmd";
@@ -38,6 +37,7 @@ import { VcdisconnectCmd } from "./commands/VcdisconnectCmd";
 import { ModActionsPlugin } from "../ModActions/ModActionsPlugin";
 import { refreshMembersIfNeeded } from "./refreshMembers";
 import { RoleInfoCmd } from "./commands/RoleInfoCmd";
+import { EmojiInfoCmd } from "./commands/EmojiInfoCmd";
 
 const defaultOptions: PluginOptions<UtilityPluginType> = {
   config: {
@@ -52,6 +52,7 @@ const defaultOptions: PluginOptions<UtilityPluginType> = {
     can_messageinfo: false,
     can_userinfo: false,
     can_roleinfo: false,
+    can_emojiinfo: false,
     can_snowflake: false,
     can_reload_guild: false,
     can_nickname: false,
@@ -82,6 +83,7 @@ const defaultOptions: PluginOptions<UtilityPluginType> = {
         can_messageinfo: true,
         can_userinfo: true,
         can_roleinfo: true,
+        can_emojiinfo: true,
         can_snowflake: true,
         can_nickname: true,
         can_vcmove: true,
@@ -142,6 +144,7 @@ export const UtilityPlugin = zeppelinGuildPlugin<UtilityPluginType>()("utility",
     InfoCmd,
     SnowflakeInfoCmd,
     RoleInfoCmd,
+    EmojiInfoCmd,
   ],
 
   onLoad(pluginData) {

--- a/backend/src/plugins/Utility/UtilityPlugin.ts
+++ b/backend/src/plugins/Utility/UtilityPlugin.ts
@@ -37,6 +37,7 @@ import { TimeAndDatePlugin } from "../TimeAndDate/TimeAndDatePlugin";
 import { VcdisconnectCmd } from "./commands/VcdisconnectCmd";
 import { ModActionsPlugin } from "../ModActions/ModActionsPlugin";
 import { refreshMembersIfNeeded } from "./refreshMembers";
+import { RoleInfoCmd } from "./commands/RoleInfoCmd";
 
 const defaultOptions: PluginOptions<UtilityPluginType> = {
   config: {
@@ -50,6 +51,7 @@ const defaultOptions: PluginOptions<UtilityPluginType> = {
     can_channelinfo: false,
     can_messageinfo: false,
     can_userinfo: false,
+    can_roleinfo: false,
     can_snowflake: false,
     can_reload_guild: false,
     can_nickname: false,
@@ -79,6 +81,7 @@ const defaultOptions: PluginOptions<UtilityPluginType> = {
         can_channelinfo: true,
         can_messageinfo: true,
         can_userinfo: true,
+        can_roleinfo: true,
         can_snowflake: true,
         can_nickname: true,
         can_vcmove: true,
@@ -138,6 +141,7 @@ export const UtilityPlugin = zeppelinGuildPlugin<UtilityPluginType>()("utility",
     MessageInfoCmd,
     InfoCmd,
     SnowflakeInfoCmd,
+    RoleInfoCmd,
   ],
 
   onLoad(pluginData) {

--- a/backend/src/plugins/Utility/commands/EmojiInfoCmd.ts
+++ b/backend/src/plugins/Utility/commands/EmojiInfoCmd.ts
@@ -1,0 +1,32 @@
+import { utilityCmd } from "../types";
+import { commandTypeHelpers as ct } from "../../../commandTypes";
+import { sendErrorMessage } from "../../../pluginUtils";
+import { customEmojiRegex } from "../../../utils";
+import { getEmojiInfoEmbed } from "../functions/getEmojiInfoEmbed";
+
+export const EmojiInfoCmd = utilityCmd({
+  trigger: ["emoji", "emojiinfo"],
+  description: "Show information about an emoji",
+  usage: "!emoji 106391128718245888",
+  permission: "can_emojiinfo",
+
+  signature: {
+    emoji: ct.string({ required: false }),
+  },
+
+  async run({ message, args, pluginData }) {
+    const emojiIdMatch = args.emoji.match(customEmojiRegex);
+    if (!emojiIdMatch?.[2]) {
+      sendErrorMessage(pluginData, message.channel, "Emoji not found");
+      return;
+    }
+
+    const embed = await getEmojiInfoEmbed(pluginData, emojiIdMatch[2]);
+    if (!embed) {
+      sendErrorMessage(pluginData, message.channel, "Emoji not found");
+      return;
+    }
+
+    message.channel.createMessage({ embed });
+  },
+});

--- a/backend/src/plugins/Utility/commands/InfoCmd.ts
+++ b/backend/src/plugins/Utility/commands/InfoCmd.ts
@@ -2,7 +2,7 @@ import { utilityCmd } from "../types";
 import { commandTypeHelpers as ct } from "../../../commandTypes";
 import { sendErrorMessage } from "../../../pluginUtils";
 import { getInviteInfoEmbed } from "../functions/getInviteInfoEmbed";
-import { isValidSnowflake, parseInviteCodeInput, resolveInvite, resolveUser } from "../../../utils";
+import { customEmojiRegex, isValidSnowflake, parseInviteCodeInput, resolveInvite, resolveUser } from "../../../utils";
 import { getUserInfoEmbed } from "../functions/getUserInfoEmbed";
 import { resolveMessageTarget } from "../../../utils/resolveMessageTarget";
 import { canReadChannel } from "../../../utils/canReadChannel";
@@ -13,6 +13,7 @@ import { getChannelId, getRoleId } from "knub/dist/utils";
 import { getGuildPreview } from "../functions/getGuildPreview";
 import { getSnowflakeInfoEmbed } from "../functions/getSnowflakeInfoEmbed";
 import { getRoleInfoEmbed } from "../functions/getRoleInfoEmbed";
+import { getEmojiInfoEmbed } from "../functions/getEmojiInfoEmbed";
 
 export const InfoCmd = utilityCmd({
   trigger: "info",
@@ -114,7 +115,15 @@ export const InfoCmd = utilityCmd({
       return;
     }
 
-    // TODO: 8. Emoji ID
+    // 8. Emoji
+    const emojiIdMatch = value.match(customEmojiRegex);
+    if (emojiIdMatch?.[2] && userCfg.can_emojiinfo) {
+      const embed = await getEmojiInfoEmbed(pluginData, emojiIdMatch[2]);
+      if (embed) {
+        message.channel.createMessage({ embed });
+        return;
+      }
+    }
 
     // 9. Arbitrary ID
     if (isValidSnowflake(value) && userCfg.can_snowflake) {

--- a/backend/src/plugins/Utility/commands/InfoCmd.ts
+++ b/backend/src/plugins/Utility/commands/InfoCmd.ts
@@ -106,7 +106,7 @@ export const InfoCmd = utilityCmd({
       }
     }
 
-    // 7. Role ID
+    // 7. Role
     const roleId = getRoleId(value);
     const role = roleId && pluginData.guild.roles.get(roleId);
     if (role && userCfg.can_roleinfo) {

--- a/backend/src/plugins/Utility/commands/InfoCmd.ts
+++ b/backend/src/plugins/Utility/commands/InfoCmd.ts
@@ -9,9 +9,10 @@ import { canReadChannel } from "../../../utils/canReadChannel";
 import { getMessageInfoEmbed } from "../functions/getMessageInfoEmbed";
 import { getChannelInfoEmbed } from "../functions/getChannelInfoEmbed";
 import { getServerInfoEmbed } from "../functions/getServerInfoEmbed";
-import { getChannelId } from "knub/dist/utils";
+import { getChannelId, getRoleId } from "knub/dist/utils";
 import { getGuildPreview } from "../functions/getGuildPreview";
 import { getSnowflakeInfoEmbed } from "../functions/getSnowflakeInfoEmbed";
+import { getRoleInfoEmbed } from "../functions/getRoleInfoEmbed";
 
 export const InfoCmd = utilityCmd({
   trigger: "info",
@@ -104,14 +105,25 @@ export const InfoCmd = utilityCmd({
       }
     }
 
-    // 7. Arbitrary ID
+    // 7. Role ID
+    const roleId = getRoleId(value);
+    const role = roleId && pluginData.guild.roles.get(roleId);
+    if (role && userCfg.can_roleinfo) {
+      const embed = await getRoleInfoEmbed(pluginData, role, message.author.id);
+      message.channel.createMessage({ embed });
+      return;
+    }
+
+    // TODO: 8. Emoji ID
+
+    // 9. Arbitrary ID
     if (isValidSnowflake(value) && userCfg.can_snowflake) {
       const embed = await getSnowflakeInfoEmbed(pluginData, value, true, message.author.id);
       message.channel.createMessage({ embed });
       return;
     }
 
-    // 7. No can do
+    // 10. No can do
     sendErrorMessage(
       pluginData,
       message.channel,

--- a/backend/src/plugins/Utility/commands/RoleInfoCmd.ts
+++ b/backend/src/plugins/Utility/commands/RoleInfoCmd.ts
@@ -1,0 +1,28 @@
+import { utilityCmd } from "../types";
+import { commandTypeHelpers as ct } from "../../../commandTypes";
+import { sendErrorMessage } from "../../../pluginUtils";
+import { getRoleInfoEmbed } from "../functions/getRoleInfoEmbed";
+
+export const RoleInfoCmd = utilityCmd({
+  trigger: ["role", "roleinfo"],
+  description: "Show information about a role",
+  usage: "!role 106391128718245888",
+  permission: "can_roleinfo",
+
+  signature: {
+    role: ct.role({ required: false }),
+  },
+
+  async run({ message, args, pluginData }) {
+    const roleId = args.role?.id;
+    const role = roleId && pluginData.guild.roles.get(roleId);
+    if (!role) {
+      sendErrorMessage(pluginData, message.channel, "Role not found");
+      return;
+    }
+
+    const embed = await getRoleInfoEmbed(pluginData, role, message.author.id);
+
+    message.channel.createMessage({ embed });
+  },
+});

--- a/backend/src/plugins/Utility/commands/RoleInfoCmd.ts
+++ b/backend/src/plugins/Utility/commands/RoleInfoCmd.ts
@@ -14,14 +14,12 @@ export const RoleInfoCmd = utilityCmd({
   },
 
   async run({ message, args, pluginData }) {
-    const roleId = args.role?.id;
-    const role = roleId && pluginData.guild.roles.get(roleId);
-    if (!role) {
+    if (!args.role) {
       sendErrorMessage(pluginData, message.channel, "Role not found");
       return;
     }
 
-    const embed = await getRoleInfoEmbed(pluginData, role, message.author.id);
+    const embed = await getRoleInfoEmbed(pluginData, args.role, message.author.id);
 
     message.channel.createMessage({ embed });
   },

--- a/backend/src/plugins/Utility/commands/RoleInfoCmd.ts
+++ b/backend/src/plugins/Utility/commands/RoleInfoCmd.ts
@@ -10,17 +10,11 @@ export const RoleInfoCmd = utilityCmd({
   permission: "can_roleinfo",
 
   signature: {
-    role: ct.role({ required: false }),
+    role: ct.role({ required: true }),
   },
 
   async run({ message, args, pluginData }) {
-    if (!args.role) {
-      sendErrorMessage(pluginData, message.channel, "Role not found");
-      return;
-    }
-
     const embed = await getRoleInfoEmbed(pluginData, args.role, message.author.id);
-
     message.channel.createMessage({ embed });
   },
 });

--- a/backend/src/plugins/Utility/functions/getEmojiInfoEmbed.ts
+++ b/backend/src/plugins/Utility/functions/getEmojiInfoEmbed.ts
@@ -1,0 +1,34 @@
+import { EmbedOptions } from "eris";
+import { GuildPluginData } from "knub";
+import { UtilityPluginType } from "../types";
+import { trimLines, preEmbedPadding, EmbedWith } from "../../../utils";
+
+export async function getEmojiInfoEmbed(
+  pluginData: GuildPluginData<UtilityPluginType>,
+  emojiId: string,
+): Promise<EmbedOptions | null> {
+  const emoji = pluginData.guild.emojis.find(e => e.id === emojiId);
+  if (!emoji) {
+    return null;
+  }
+
+  const embed: EmbedWith<"fields"> = {
+    fields: [],
+  };
+
+  embed.author = {
+    name: `Emoji:  ${emoji.name}`,
+    icon_url: `https://cdn.discordapp.com/emojis/${emoji.id}.${emoji.animated ? "gif" : "png"}?v=1`,
+  };
+
+  embed.fields.push({
+    name: preEmbedPadding + "Emoji information",
+    value: trimLines(`
+      Name: **${emoji.name}**
+      ID: \`${emoji.id}\`
+      Animated: **${emoji.animated ? "Yes" : "No"}**
+    `),
+  });
+
+  return embed;
+}

--- a/backend/src/plugins/Utility/functions/getRoleInfoEmbed.ts
+++ b/backend/src/plugins/Utility/functions/getRoleInfoEmbed.ts
@@ -6,7 +6,7 @@ import moment from "moment-timezone";
 import humanizeDuration from "humanize-duration";
 import { TimeAndDatePlugin } from "../../TimeAndDate/TimeAndDatePlugin";
 
-const MENTION = "https://cdn.discordapp.com/attachments/705009450855039042/839284872152481792/mention.png";
+const MENTION_ICON = "https://cdn.discordapp.com/attachments/705009450855039042/839284872152481792/mention.png";
 
 export async function getRoleInfoEmbed(
   pluginData: GuildPluginData<UtilityPluginType>,
@@ -19,7 +19,7 @@ export async function getRoleInfoEmbed(
 
   embed.author = {
     name: `Role:  ${role.name}`,
-    icon_url: MENTION,
+    icon_url: MENTION_ICON,
   };
 
   embed.color = role.color;
@@ -38,6 +38,7 @@ export async function getRoleInfoEmbed(
   const rolePerms = Object.keys(role.permissions.json)
     .map(p =>
       p
+        // Voice channel related permission names start with 'voice'
         .replace(/^voice/i, "")
         .replace(/([a-z])([A-Z])/g, "$1 $2")
         .toLowerCase()

--- a/backend/src/plugins/Utility/functions/getRoleInfoEmbed.ts
+++ b/backend/src/plugins/Utility/functions/getRoleInfoEmbed.ts
@@ -1,0 +1,67 @@
+import { EmbedOptions, Role } from "eris";
+import { GuildPluginData } from "knub";
+import { UtilityPluginType } from "../types";
+import { trimLines, preEmbedPadding, EmbedWith } from "../../../utils";
+import moment from "moment-timezone";
+import humanizeDuration from "humanize-duration";
+import { TimeAndDatePlugin } from "../../TimeAndDate/TimeAndDatePlugin";
+
+const MENTION = "https://cdn.discordapp.com/attachments/705009450855039042/839284872152481792/mention.png";
+
+export async function getRoleInfoEmbed(
+  pluginData: GuildPluginData<UtilityPluginType>,
+  role: Role,
+  requestMemberId?: string,
+): Promise<EmbedOptions> {
+  const embed: EmbedWith<"fields"> = {
+    fields: [],
+  };
+
+  embed.author = {
+    name: `Role:  ${role.name}`,
+    icon_url: MENTION,
+  };
+
+  embed.color = role.color;
+
+  const createdAt = moment.utc(role.createdAt, "x");
+  const timeAndDate = pluginData.getPlugin(TimeAndDatePlugin);
+  const tzCreatedAt = requestMemberId
+    ? await timeAndDate.inMemberTz(requestMemberId, createdAt)
+    : timeAndDate.inGuildTz(createdAt);
+  const prettyCreatedAt = tzCreatedAt.format(timeAndDate.getDateFormat("pretty_datetime"));
+  const roleAge = humanizeDuration(Date.now() - role.createdAt, {
+    largest: 2,
+    round: true,
+  });
+
+  const rolePerms = Object.keys(role.permissions.json)
+    .map(p =>
+      p
+        .replace(/^voice/i, "")
+        .replace(/([a-z])([A-Z])/g, "$1 $2")
+        .toLowerCase()
+        .replace(/(^\w{1})|(\s{1}\w{1})/g, l => l.toUpperCase()),
+    )
+    .join(", ");
+
+  embed.fields.push({
+    name: preEmbedPadding + "Role information",
+    value: trimLines(`
+      Name: **${role.name}**
+      ID: \`${role.id}\`
+      Created: **${roleAge} ago** (\`${prettyCreatedAt}\`)
+      Position: **${role.position}**
+      Color: **#${role.color
+        .toString(16)
+        .toUpperCase()
+        .padStart(6, "0")}**
+      Mentionable: **${role.mentionable ? "Yes" : "No"}**
+      Hoisted: **${role.hoist ? "Yes" : "No"}**
+      Permissions: \`${rolePerms}\`
+      Mention: <@&${role.id}> (\`<@&${role.id}>\`)
+    `),
+  });
+
+  return embed;
+}

--- a/backend/src/plugins/Utility/functions/getRoleInfoEmbed.ts
+++ b/backend/src/plugins/Utility/functions/getRoleInfoEmbed.ts
@@ -35,16 +35,17 @@ export async function getRoleInfoEmbed(
     round: true,
   });
 
-  const rolePerms = Object.keys(role.permissions.json)
-    .map(p =>
-      p
-        // Voice channel related permission names start with 'voice'
-        .replace(/^voice/i, "")
-        .replace(/([a-z])([A-Z])/g, "$1 $2")
-        .toLowerCase()
-        .replace(/(^\w{1})|(\s{1}\w{1})/g, l => l.toUpperCase()),
-    )
-    .join(", ");
+  const rolePerms = Object.keys(role.permissions.json).map(p =>
+    p
+      // Voice channel related permission names start with 'voice'
+      .replace(/^voice/i, "")
+      .replace(/([a-z])([A-Z])/g, "$1 $2")
+      .toLowerCase()
+      .replace(/(^\w{1})|(\s{1}\w{1})/g, l => l.toUpperCase()),
+  );
+
+  // -1 because of the @everyone role
+  const totalGuildRoles = pluginData.guild.roles.size - 1;
 
   embed.fields.push({
     name: preEmbedPadding + "Role information",
@@ -52,14 +53,14 @@ export async function getRoleInfoEmbed(
       Name: **${role.name}**
       ID: \`${role.id}\`
       Created: **${roleAge} ago** (\`${prettyCreatedAt}\`)
-      Position: **${role.position}**
+      Position: **${role.position} / ${totalGuildRoles}**
       Color: **#${role.color
         .toString(16)
         .toUpperCase()
         .padStart(6, "0")}**
       Mentionable: **${role.mentionable ? "Yes" : "No"}**
       Hoisted: **${role.hoist ? "Yes" : "No"}**
-      Permissions: \`${rolePerms}\`
+      Permissions: \`${rolePerms.length ? rolePerms.join(", ") : "None"}\`
       Mention: <@&${role.id}> (\`<@&${role.id}>\`)
     `),
   });

--- a/backend/src/plugins/Utility/types.ts
+++ b/backend/src/plugins/Utility/types.ts
@@ -19,6 +19,7 @@ export const ConfigSchema = t.type({
   can_messageinfo: t.boolean,
   can_userinfo: t.boolean,
   can_roleinfo: t.boolean,
+  can_emojiinfo: t.boolean,
   can_snowflake: t.boolean,
   can_reload_guild: t.boolean,
   can_nickname: t.boolean,

--- a/backend/src/plugins/Utility/types.ts
+++ b/backend/src/plugins/Utility/types.ts
@@ -18,6 +18,7 @@ export const ConfigSchema = t.type({
   can_channelinfo: t.boolean,
   can_messageinfo: t.boolean,
   can_userinfo: t.boolean,
+  can_roleinfo: t.boolean,
   can_snowflake: t.boolean,
   can_reload_guild: t.boolean,
   can_nickname: t.boolean,


### PR DESCRIPTION
The role-info command was based on the one from https://github.com/Dragory/ZeppelinBot/pull/116

On the emoji-info command, only custom emojis from the guild the command was run on can be used in the command