### PR TITLE
Add option for default duration of mutes

### DIFF
--- a/backend/src/plugins/ModActions/functions/actualMuteUserCmd.ts
+++ b/backend/src/plugins/ModActions/functions/actualMuteUserCmd.ts
@@ -36,7 +36,6 @@ export async function actualMuteUserCmd(
     pp = msg.author;
   }
 
-  const timeUntilUnmute = args.time && humanizeDuration(args.time);
   const reason = args.reason ? formatReasonWithAttachments(args.reason, msg.attachments) : undefined;
 
   let muteResult: MuteResult;
@@ -77,16 +76,16 @@ export async function actualMuteUserCmd(
 
   // Confirm the action to the moderator
   let response;
-  if (args.time) {
+  if (muteResult.timeUntilUnmute) {
     if (muteResult.updatedExistingMute) {
       response = asSingleLine(`
         Updated **${user.username}#${user.discriminator}**'s
-        mute to ${timeUntilUnmute} (Case #${muteResult.case.case_number})
+        mute to ${muteResult.timeUntilUnmute} (Case #${muteResult.case.case_number})
       `);
     } else {
       response = asSingleLine(`
         Muted **${user.username}#${user.discriminator}**
-        for ${timeUntilUnmute} (Case #${muteResult.case.case_number})
+        for ${muteResult.timeUntilUnmute} (Case #${muteResult.case.case_number})
       `);
     }
   } else {

--- a/backend/src/plugins/Mutes/MutesPlugin.ts
+++ b/backend/src/plugins/Mutes/MutesPlugin.ts
@@ -26,6 +26,7 @@ const defaultOptions = {
     mute_role: null,
     move_to_voice_channel: null,
     kick_from_voice_channel: false,
+    default_duration: null,
 
     dm_on_mute: false,
     dm_on_update: false,

--- a/backend/src/plugins/Mutes/functions/muteUser.ts
+++ b/backend/src/plugins/Mutes/functions/muteUser.ts
@@ -10,6 +10,7 @@ import {
   UserNotificationResult,
   resolveMember,
   UserNotificationMethod,
+  convertDelayStringToMS,
 } from "../../../utils";
 import { renderTemplate } from "../../../templateFormatter";
 import { MemberOptions, TextChannel, User } from "eris";
@@ -37,8 +38,6 @@ export async function muteUser(
     throw new RecoverablePluginError(ERRORS.NO_MUTE_ROLE_IN_CONFIG);
   }
 
-  const timeUntilUnmute = muteTime ? humanizeDuration(muteTime) : "indefinite";
-
   // No mod specified -> mark Zeppelin as the mod
   if (!muteOptions.caseArgs?.modId) {
     muteOptions.caseArgs = muteOptions.caseArgs ?? {};
@@ -53,6 +52,13 @@ export async function muteUser(
 
   const member = await resolveMember(pluginData.client, pluginData.guild, user.id, true); // Grab the fresh member so we don't have stale role info
   const config = pluginData.config.getMatchingConfig({ member, userId });
+
+  muteTime = muteTime !== undefined
+    ? muteTime
+    : config.default_duration
+    ? convertDelayStringToMS(config.default_duration)!
+    : undefined;
+  const timeUntilUnmute = muteTime ? humanizeDuration(muteTime) : "indefinite";
 
   let rolesToRestore: string[] = [];
   if (member) {
@@ -245,6 +251,7 @@ export async function muteUser(
 
   return {
     case: theCase,
+    timeUntilUnmute: timeUntilUnmute,
     notifyResult,
     updatedExistingMute: !!existingMute,
   };

--- a/backend/src/plugins/Mutes/types.ts
+++ b/backend/src/plugins/Mutes/types.ts
@@ -1,5 +1,5 @@
 import * as t from "io-ts";
-import { tNullable, UserNotificationMethod, UserNotificationResult } from "../../utils";
+import { tDelayString, tNullable, UserNotificationMethod, UserNotificationResult } from "../../utils";
 import { Mute } from "../../data/entities/Mute";
 import { Member } from "eris";
 import { Case } from "../../data/entities/Case";
@@ -16,6 +16,7 @@ export const ConfigSchema = t.type({
   mute_role: tNullable(t.string),
   move_to_voice_channel: tNullable(t.string),
   kick_from_voice_channel: t.boolean,
+  default_duration: tNullable(tDelayString),
 
   dm_on_mute: t.boolean,
   dm_on_update: t.boolean,
@@ -64,6 +65,7 @@ export interface IMuteWithDetails extends Mute {
 
 export type MuteResult = {
   case: Case;
+  timeUntilUnmute: string;
   notifyResult: UserNotificationResult;
   updatedExistingMute: boolean;
 };


### PR DESCRIPTION
Allow users to set a default duration for all mutes (including automod) when a time is not specified. Set via `default_duration: Nullable<tDelayString>` in mutes config. Default/`null` is indefinite mute.

Notes:
- I don't have a full test setup currently. So can't thoroughly test (e.g. mass mute and automod mutes)
- Applies to all mutes. Could be changed to just apply to manual mutes? Though then would be best to move to mod actions.
- If a user tries to mute an already muted user without specifying a length it will update the mute to the default. This mirrors how it currently works with indefinite mutes.