### PR TITLE
allow yaml aliases on config

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1,6 +1,5 @@
 import { BaseConfig, Knub } from "knub";
 import * as t from "io-ts";
-import { Message } from "eris";
 
 export interface ZeppelinGuildConfig extends BaseConfig<any> {
   success_emoji?: string;
@@ -24,6 +23,9 @@ export const ZeppelinGuildConfigSchema = t.type({
   // Deprecated
   timezone: t.string,
   date_formats: t.unknown,
+
+  // YAML Stuff
+  aliases: t.unknown,
 });
 export const PartialZeppelinGuildConfigSchema = t.partial(ZeppelinGuildConfigSchema.props);
 


### PR DESCRIPTION
Removes this error and allows the user to save the config
![image](https://user-images.githubusercontent.com/42935195/120533842-14402600-c3d9-11eb-8003-9bb83c962016.png)
