### PR TITLE
Fixed typo in !removerole

### DIFF
--- a/backend/src/plugins/Roles/commands/RemoveRoleCmd.ts
+++ b/backend/src/plugins/Roles/commands/RemoveRoleCmd.ts
@@ -61,7 +61,7 @@ export const RemoveRoleCmd = rolesCmd({
     sendSuccessMessage(
       pluginData,
       msg.channel,
-      `Removed role **${role.name}** removed from ${verboseUserMention(args.member.user)}!`,
+      `Removed role **${role.name}** from ${verboseUserMention(args.member.user)}!`,
     );
   },
 });


### PR DESCRIPTION
Fixes small typo in the `!removerole` command.