### PR TITLE
Automod invite filter updated regex

### DIFF
--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -743,10 +743,11 @@ export function isNotNull(value): value is Exclude<typeof value, null> {
 // discordapp.com/invite/<code>
 // discord.gg/invite/<code>
 // discord.gg/<code>
-const quickInviteDetection = /(?:discord.com|discordapp.com)\/invite\/([a-z0-9\-]+)|discord.gg\/(?:\S+\/)?([a-z0-9\-]+)/gi;
+// discord.com/friend-invite/<code>
+const quickInviteDetection = /(?:discord.com|discordapp.com)\/(?:invite|friend-invite)\/([a-z0-9\-]+)|discord.gg\/(?:\S+\/)?([a-z0-9\-]+)/gi;
 
 const isInviteHostRegex = /(?:^|\.)(?:discord.gg|discord.com|discordapp.com)$/i;
-const longInvitePathRegex = /^\/invite\/([a-z0-9\-]+)$/i;
+const longInvitePathRegex = /^^\/(?:invite|friend-invite)\/([a-z0-9\-]+)$/i;
 
 export function getInviteCodesInString(str: string): string[] {
   const inviteCodes: string[] = [];
@@ -778,6 +779,8 @@ export function getInviteCodesInString(str: string): string[] {
 
       // discord.com/invite/<code>[/anything]
       // discordapp.com/invite/<code>[/anything]
+      // discord.com/friend-invite/<code>[/anything]
+      // discordapp.com/friend-invite/<code>[/anything]
       const longInviteMatch = url.pathname.match(longInvitePathRegex);
       if (longInviteMatch) {
         return longInviteMatch[1];

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -747,7 +747,7 @@ export function isNotNull(value): value is Exclude<typeof value, null> {
 const quickInviteDetection = /(?:discord.com|discordapp.com)\/(?:invite|friend-invite)\/([a-z0-9\-]+)|discord.gg\/(?:\S+\/)?([a-z0-9\-]+)/gi;
 
 const isInviteHostRegex = /(?:^|\.)(?:discord.gg|discord.com|discordapp.com)$/i;
-const longInvitePathRegex = /^^\/(?:invite|friend-invite)\/([a-z0-9\-]+)$/i;
+const longInvitePathRegex = /^\/(?:friend-)?invite\/([a-z0-9\-]+)$/i;
 
 export function getInviteCodesInString(str: string): string[] {
   const inviteCodes: string[] = [];

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -744,7 +744,7 @@ export function isNotNull(value): value is Exclude<typeof value, null> {
 // discord.gg/invite/<code>
 // discord.gg/<code>
 // discord.com/friend-invite/<code>
-const quickInviteDetection = /(?:discord.com|discordapp.com)\/(?:invite|friend-invite)\/([a-z0-9\-]+)|discord.gg\/(?:\S+\/)?([a-z0-9\-]+)/gi;
+const quickInviteDetection = /discord(?:app)?\.com\/(?:friend-)?invite\/([a-z0-9\-]+)|discord\.gg\/(?:\S+\/)?([a-z0-9\-]+)/gi;
 
 const isInviteHostRegex = /(?:^|\.)(?:discord.gg|discord.com|discordapp.com)$/i;
 const longInvitePathRegex = /^\/(?:friend-)?invite\/([a-z0-9\-]+)$/i;


### PR DESCRIPTION
Graphic on discord pointed out this new bypass, just updating the regex.
`https://discord.com/friend-invite/code#`

Also, currently automod will double-trigger invite (and probably others as well) filters due to embeds (message update), even if the violation is the exact same. I'm not sure what the best fix and impl is here, so I won't write up anything, but in theory I imagine it would have to be either checking message content is the exact same on msg update, or just ignoring duplicate violations on the same filter for the same data (i.e. if alrd flagged invite code `1234`, let's not flag it again for the same message)