### PR TITLE
Added thread_create and thread_delete automod triggers

### DIFF
--- a/backend/src/data/GuildSavedMessages.ts
+++ b/backend/src/data/GuildSavedMessages.ts
@@ -140,38 +140,10 @@ export class GuildSavedMessages extends BaseGuildRepository<SavedMessage> {
     return data;
   }
 
-<<<<<<< HEAD
   protected async _processEntityFromDB(entity: SavedMessage | undefined) {
     if (entity == null) {
       return entity;
     }
-=======
-  public msgToSavedMessage(message: Message): SavedMessage {
-    const postedAt = moment.utc(message.createdTimestamp, "x").format("YYYY-MM-DD HH:mm:ss");
-
-    return {
-      data: this.msgToSavedMessageData(message),
-      id: message.id,
-      guild_id: (message.channel as GuildChannel).guildId,
-      channel_id: message.channelId,
-      user_id: message.author.id,
-      is_bot: message.author.bot,
-      posted_at: postedAt,
-      // @ts-expect-error
-      deleted_at: null,
-      is_permanent: false,
-    };
-  }
-
-  find(id) {
-    return this.messages
-      .createQueryBuilder()
-      .where("guild_id = :guild_id", { guild_id: this.guildId })
-      .andWhere("id = :id", { id })
-      .andWhere("deleted_at IS NULL")
-      .getOne();
-  }
->>>>>>> 14aceada (use savedmessages state instead of static method)
 
     entity.data = await decryptJson(entity.data as unknown as string);
     return entity;
@@ -251,16 +223,8 @@ export class GuildSavedMessages extends BaseGuildRepository<SavedMessage> {
     await this.insertBulk(items);
   }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   protected async msgToInsertReadyEntity(msg: Message): Promise<Partial<SavedMessage>> {
     const savedMessageData = this.msgToSavedMessageData(msg);
-=======
-    const savedMessageData = GuildSavedMessages.msgToSavedMessageData(msg);
->>>>>>> 95a0ce8c (clean up)
-=======
-    const savedMessageData = this.msgToSavedMessageData(msg);
->>>>>>> 14aceada (use savedmessages state instead of static method)
     const postedAt = moment.utc(msg.createdTimestamp, "x").format("YYYY-MM-DD HH:mm:ss");
 
     return {
@@ -360,15 +324,9 @@ export class GuildSavedMessages extends BaseGuildRepository<SavedMessage> {
     this.events.emit(`update:${id}`, [newMessage, oldMessage]);
   }
 
-<<<<<<< HEAD
   async saveEditFromMsg(msg: Message): Promise<void> {
     const newData = this.msgToSavedMessageData(msg);
     await this.saveEdit(msg.id, newData);
-=======
-  async saveEditFromMsg(msg: Message) {
-    const newData = this.msgToSavedMessageData(msg);
-    return this.saveEdit(msg.id, newData);
->>>>>>> 95a0ce8c (clean up)
   }
 
   async setPermanent(id: string): Promise<void> {

--- a/backend/src/data/GuildSavedMessages.ts
+++ b/backend/src/data/GuildSavedMessages.ts
@@ -140,10 +140,38 @@ export class GuildSavedMessages extends BaseGuildRepository<SavedMessage> {
     return data;
   }
 
+<<<<<<< HEAD
   protected async _processEntityFromDB(entity: SavedMessage | undefined) {
     if (entity == null) {
       return entity;
     }
+=======
+  public msgToSavedMessage(message: Message): SavedMessage {
+    const postedAt = moment.utc(message.createdTimestamp, "x").format("YYYY-MM-DD HH:mm:ss");
+
+    return {
+      data: this.msgToSavedMessageData(message),
+      id: message.id,
+      guild_id: (message.channel as GuildChannel).guildId,
+      channel_id: message.channelId,
+      user_id: message.author.id,
+      is_bot: message.author.bot,
+      posted_at: postedAt,
+      // @ts-expect-error
+      deleted_at: null,
+      is_permanent: false,
+    };
+  }
+
+  find(id) {
+    return this.messages
+      .createQueryBuilder()
+      .where("guild_id = :guild_id", { guild_id: this.guildId })
+      .andWhere("id = :id", { id })
+      .andWhere("deleted_at IS NULL")
+      .getOne();
+  }
+>>>>>>> 14aceada (use savedmessages state instead of static method)
 
     entity.data = await decryptJson(entity.data as unknown as string);
     return entity;
@@ -224,11 +252,15 @@ export class GuildSavedMessages extends BaseGuildRepository<SavedMessage> {
   }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   protected async msgToInsertReadyEntity(msg: Message): Promise<Partial<SavedMessage>> {
     const savedMessageData = this.msgToSavedMessageData(msg);
 =======
     const savedMessageData = GuildSavedMessages.msgToSavedMessageData(msg);
 >>>>>>> 95a0ce8c (clean up)
+=======
+    const savedMessageData = this.msgToSavedMessageData(msg);
+>>>>>>> 14aceada (use savedmessages state instead of static method)
     const postedAt = moment.utc(msg.createdTimestamp, "x").format("YYYY-MM-DD HH:mm:ss");
 
     return {
@@ -334,7 +366,7 @@ export class GuildSavedMessages extends BaseGuildRepository<SavedMessage> {
     await this.saveEdit(msg.id, newData);
 =======
   async saveEditFromMsg(msg: Message) {
-    const newData = GuildSavedMessages.msgToSavedMessageData(msg);
+    const newData = this.msgToSavedMessageData(msg);
     return this.saveEdit(msg.id, newData);
 >>>>>>> 95a0ce8c (clean up)
   }

--- a/backend/src/data/GuildSavedMessages.ts
+++ b/backend/src/data/GuildSavedMessages.ts
@@ -25,23 +25,6 @@ export class GuildSavedMessages extends BaseGuildRepository<SavedMessage> {
     this.toBePermanent = new Set();
   }
 
-  public msgToSavedMessage(message: Message): SavedMessage {
-    const postedAt = moment.utc(message.createdTimestamp, "x").format("YYYY-MM-DD HH:mm:ss");
-
-    return {
-      data: this.msgToSavedMessageData(message),
-      id: message.id,
-      guild_id: (message.channel as GuildChannel).guildId,
-      channel_id: message.channelId,
-      user_id: message.author.id,
-      is_bot: message.author.bot,
-      posted_at: postedAt,
-      // @ts-expect-error
-      deleted_at: null,
-      is_permanent: false,
-    };
-  }
-
   protected msgToSavedMessageData(msg: Message): ISavedMessageData {
     const data: ISavedMessageData = {
       author: {

--- a/backend/src/data/GuildSavedMessages.ts
+++ b/backend/src/data/GuildSavedMessages.ts
@@ -25,6 +25,23 @@ export class GuildSavedMessages extends BaseGuildRepository<SavedMessage> {
     this.toBePermanent = new Set();
   }
 
+  public msgToSavedMessage(message: Message): SavedMessage {
+    const postedAt = moment.utc(message.createdTimestamp, "x").format("YYYY-MM-DD HH:mm:ss");
+
+    return {
+      data: this.msgToSavedMessageData(message),
+      id: message.id,
+      guild_id: (message.channel as GuildChannel).guildId,
+      channel_id: message.channelId,
+      user_id: message.author.id,
+      is_bot: message.author.bot,
+      posted_at: postedAt,
+      // @ts-expect-error
+      deleted_at: null,
+      is_permanent: false,
+    };
+  }
+
   protected msgToSavedMessageData(msg: Message): ISavedMessageData {
     const data: ISavedMessageData = {
       author: {
@@ -206,8 +223,12 @@ export class GuildSavedMessages extends BaseGuildRepository<SavedMessage> {
     await this.insertBulk(items);
   }
 
+<<<<<<< HEAD
   protected async msgToInsertReadyEntity(msg: Message): Promise<Partial<SavedMessage>> {
     const savedMessageData = this.msgToSavedMessageData(msg);
+=======
+    const savedMessageData = GuildSavedMessages.msgToSavedMessageData(msg);
+>>>>>>> 95a0ce8c (clean up)
     const postedAt = moment.utc(msg.createdTimestamp, "x").format("YYYY-MM-DD HH:mm:ss");
 
     return {
@@ -307,9 +328,15 @@ export class GuildSavedMessages extends BaseGuildRepository<SavedMessage> {
     this.events.emit(`update:${id}`, [newMessage, oldMessage]);
   }
 
+<<<<<<< HEAD
   async saveEditFromMsg(msg: Message): Promise<void> {
     const newData = this.msgToSavedMessageData(msg);
     await this.saveEdit(msg.id, newData);
+=======
+  async saveEditFromMsg(msg: Message) {
+    const newData = GuildSavedMessages.msgToSavedMessageData(msg);
+    return this.saveEdit(msg.id, newData);
+>>>>>>> 95a0ce8c (clean up)
   }
 
   async setPermanent(id: string): Promise<void> {

--- a/backend/src/plugins/Automod/AutomodPlugin.ts
+++ b/backend/src/plugins/Automod/AutomodPlugin.ts
@@ -24,6 +24,7 @@ import { RunAutomodOnJoinEvt, RunAutomodOnLeaveEvt } from "./events/RunAutomodOn
 import { RunAutomodOnMemberUpdate } from "./events/RunAutomodOnMemberUpdate";
 import { runAutomodOnMessage } from "./events/runAutomodOnMessage";
 import { runAutomodOnModAction } from "./events/runAutomodOnModAction";
+import { RunAutomodOnThreadCreate, RunAutomodOnThreadDelete } from "./events/runAutomodOnThreadEvents";
 import { clearOldRecentNicknameChanges } from "./functions/clearOldNicknameChanges";
 import { clearOldRecentActions } from "./functions/clearOldRecentActions";
 import { clearOldRecentSpam } from "./functions/clearOldRecentSpam";
@@ -200,6 +201,8 @@ export const AutomodPlugin = zeppelinGuildPlugin<AutomodPluginType>()({
     RunAutomodOnJoinEvt,
     RunAutomodOnMemberUpdate,
     RunAutomodOnLeaveEvt,
+    RunAutomodOnThreadCreate,
+    RunAutomodOnThreadDelete,
     // Messages use message events from SavedMessages, see onLoad below
   ],
 

--- a/backend/src/plugins/Automod/events/runAutomodOnThreadEvents.ts
+++ b/backend/src/plugins/Automod/events/runAutomodOnThreadEvents.ts
@@ -6,7 +6,6 @@ export const RunAutomodOnThreadCreate = typedGuildEventListener<AutomodPluginTyp
   event: "threadCreate",
   async listener({ pluginData, args: { thread } }) {
     const user = thread.ownerId ? await pluginData.client.users.fetch(thread.ownerId).catch(() => void 0) : void 0;
-
     const context: AutomodContext = {
       timestamp: Date.now(),
       threadChange: {
@@ -14,6 +13,19 @@ export const RunAutomodOnThreadCreate = typedGuildEventListener<AutomodPluginTyp
       },
       user,
     };
+    const sourceChannel = pluginData.client.channels.cache.find(c => c.id === thread.parentId);
+    if (sourceChannel?.isText()) {
+      const sourceMessage = sourceChannel.messages.cache.find(
+        m => m.thread?.id === thread.id || m.reference?.channelId === thread.id,
+      );
+      if (sourceMessage) {
+        const message = await pluginData.state.savedMessages.find(sourceMessage.id);
+        if (message) {
+          message.channel_id = thread.id;
+          context.message = message;
+        }
+      }
+    }
 
     pluginData.state.queue.add(() => {
       runAutomod(pluginData, context);

--- a/backend/src/plugins/Automod/events/runAutomodOnThreadEvents.ts
+++ b/backend/src/plugins/Automod/events/runAutomodOnThreadEvents.ts
@@ -1,0 +1,41 @@
+import { typedGuildEventListener } from "knub";
+import { runAutomod } from "../functions/runAutomod";
+import { AutomodContext, AutomodPluginType } from "../types";
+
+export const RunAutomodOnThreadCreate = typedGuildEventListener<AutomodPluginType>()({
+  event: "threadCreate",
+  async listener({ pluginData, args: { thread } }) {
+    const user = thread.ownerId ? await pluginData.client.users.fetch(thread.ownerId).catch(() => void 0) : void 0;
+
+    const context: AutomodContext = {
+      timestamp: Date.now(),
+      threadChange: {
+        created: thread,
+      },
+      user,
+    };
+
+    pluginData.state.queue.add(() => {
+      runAutomod(pluginData, context);
+    });
+  },
+});
+
+export const RunAutomodOnThreadDelete = typedGuildEventListener<AutomodPluginType>()({
+  event: "threadDelete",
+  async listener({ pluginData, args: { thread } }) {
+    const user = thread.ownerId ? await pluginData.client.users.fetch(thread.ownerId).catch(() => void 0) : void 0;
+
+    const context: AutomodContext = {
+      timestamp: Date.now(),
+      threadChange: {
+        deleted: thread,
+      },
+      user,
+    };
+
+    pluginData.state.queue.add(() => {
+      runAutomod(pluginData, context);
+    });
+  },
+});

--- a/backend/src/plugins/Automod/events/runAutomodOnThreadEvents.ts
+++ b/backend/src/plugins/Automod/events/runAutomodOnThreadEvents.ts
@@ -1,4 +1,5 @@
 import { typedGuildEventListener } from "knub";
+import { GuildSavedMessages } from "../../../data/GuildSavedMessages";
 import { runAutomod } from "../functions/runAutomod";
 import { AutomodContext, AutomodPluginType } from "../types";
 
@@ -13,18 +14,18 @@ export const RunAutomodOnThreadCreate = typedGuildEventListener<AutomodPluginTyp
       },
       user,
     };
-    const sourceChannel = pluginData.client.channels.cache.find(c => c.id === thread.parentId);
-    if (sourceChannel?.isText()) {
+
+    // This is a hack to make this trigger compatible with the reply action
+    const sourceChannel = thread.parent ?? pluginData.client.channels.cache.find((c) => c.id === thread.parentId);
+    messageBlock: if (sourceChannel?.isText()) {
       const sourceMessage = sourceChannel.messages.cache.find(
-        m => m.thread?.id === thread.id || m.reference?.channelId === thread.id,
+        (m) => m.thread?.id === thread.id || m.reference?.channelId === thread.id,
       );
-      if (sourceMessage) {
-        const message = await pluginData.state.savedMessages.find(sourceMessage.id);
-        if (message) {
-          message.channel_id = thread.id;
-          context.message = message;
-        }
-      }
+      if (!sourceMessage) break messageBlock;
+
+      const savedMessage = pluginData.state.savedMessages.msgToSavedMessage(sourceMessage);
+      savedMessage.channel_id = thread.id;
+      context.message = savedMessage;
     }
 
     pluginData.state.queue.add(() => {

--- a/backend/src/plugins/Automod/events/runAutomodOnThreadEvents.ts
+++ b/backend/src/plugins/Automod/events/runAutomodOnThreadEvents.ts
@@ -1,5 +1,4 @@
 import { typedGuildEventListener } from "knub";
-import { GuildSavedMessages } from "../../../data/GuildSavedMessages";
 import { runAutomod } from "../functions/runAutomod";
 import { AutomodContext, AutomodPluginType } from "../types";
 

--- a/backend/src/plugins/Automod/events/runAutomodOnThreadEvents.ts
+++ b/backend/src/plugins/Automod/events/runAutomodOnThreadEvents.ts
@@ -5,27 +5,17 @@ import { AutomodContext, AutomodPluginType } from "../types";
 export const RunAutomodOnThreadCreate = typedGuildEventListener<AutomodPluginType>()({
   event: "threadCreate",
   async listener({ pluginData, args: { thread } }) {
-    const user = thread.ownerId ? await pluginData.client.users.fetch(thread.ownerId).catch(() => void 0) : void 0;
+    const user = thread.ownerId
+      ? await pluginData.client.users.fetch(thread.ownerId).catch(() => undefined)
+      : undefined;
     const context: AutomodContext = {
       timestamp: Date.now(),
       threadChange: {
         created: thread,
       },
       user,
+      channel: thread,
     };
-
-    // This is a hack to make this trigger compatible with the reply action
-    const sourceChannel = thread.parent ?? pluginData.client.channels.cache.find((c) => c.id === thread.parentId);
-    if (sourceChannel?.isText()) {
-      const sourceMessage = sourceChannel.messages.cache.find(
-        (m) => m.thread?.id === thread.id || m.reference?.channelId === thread.id,
-      );
-      if (sourceMessage) {
-        const savedMessage = pluginData.state.savedMessages.msgToSavedMessage(sourceMessage);
-        savedMessage.channel_id = thread.id;
-        context.message = savedMessage;
-      }
-    }
 
     pluginData.state.queue.add(() => {
       runAutomod(pluginData, context);
@@ -36,7 +26,9 @@ export const RunAutomodOnThreadCreate = typedGuildEventListener<AutomodPluginTyp
 export const RunAutomodOnThreadDelete = typedGuildEventListener<AutomodPluginType>()({
   event: "threadDelete",
   async listener({ pluginData, args: { thread } }) {
-    const user = thread.ownerId ? await pluginData.client.users.fetch(thread.ownerId).catch(() => void 0) : void 0;
+    const user = thread.ownerId
+      ? await pluginData.client.users.fetch(thread.ownerId).catch(() => undefined)
+      : undefined;
 
     const context: AutomodContext = {
       timestamp: Date.now(),
@@ -44,6 +36,7 @@ export const RunAutomodOnThreadDelete = typedGuildEventListener<AutomodPluginTyp
         deleted: thread,
       },
       user,
+      channel: thread,
     };
 
     pluginData.state.queue.add(() => {

--- a/backend/src/plugins/Automod/events/runAutomodOnThreadEvents.ts
+++ b/backend/src/plugins/Automod/events/runAutomodOnThreadEvents.ts
@@ -17,15 +17,15 @@ export const RunAutomodOnThreadCreate = typedGuildEventListener<AutomodPluginTyp
 
     // This is a hack to make this trigger compatible with the reply action
     const sourceChannel = thread.parent ?? pluginData.client.channels.cache.find((c) => c.id === thread.parentId);
-    messageBlock: if (sourceChannel?.isText()) {
+    if (sourceChannel?.isText()) {
       const sourceMessage = sourceChannel.messages.cache.find(
         (m) => m.thread?.id === thread.id || m.reference?.channelId === thread.id,
       );
-      if (!sourceMessage) break messageBlock;
-
-      const savedMessage = pluginData.state.savedMessages.msgToSavedMessage(sourceMessage);
-      savedMessage.channel_id = thread.id;
-      context.message = savedMessage;
+      if (sourceMessage) {
+        const savedMessage = pluginData.state.savedMessages.msgToSavedMessage(sourceMessage);
+        savedMessage.channel_id = thread.id;
+        context.message = savedMessage;
+      }
     }
 
     pluginData.state.queue.add(() => {

--- a/backend/src/plugins/Automod/events/runAutomodOnThreadEvents.ts
+++ b/backend/src/plugins/Automod/events/runAutomodOnThreadEvents.ts
@@ -8,6 +8,7 @@ export const RunAutomodOnThreadCreate = typedGuildEventListener<AutomodPluginTyp
     const user = thread.ownerId
       ? await pluginData.client.users.fetch(thread.ownerId).catch(() => undefined)
       : undefined;
+
     const context: AutomodContext = {
       timestamp: Date.now(),
       threadChange: {

--- a/backend/src/plugins/Automod/functions/runAutomod.ts
+++ b/backend/src/plugins/Automod/functions/runAutomod.ts
@@ -15,9 +15,11 @@ export async function runAutomod(pluginData: GuildPluginData<AutomodPluginType>,
   const member = context.member || (userId && pluginData.guild.members.cache.get(userId as Snowflake)) || null;
 
   const channelIdOrThreadId = context.message?.channel_id;
-  const channelOrThread = channelIdOrThreadId
-    ? (pluginData.guild.channels.cache.get(channelIdOrThreadId as Snowflake) as TextChannel | ThreadChannel)
-    : null;
+  const channelOrThread =
+    context.channel ??
+    (channelIdOrThreadId
+      ? (pluginData.guild.channels.cache.get(channelIdOrThreadId as Snowflake) as TextChannel | ThreadChannel)
+      : null);
   const channelId = channelOrThread?.isThread() ? channelOrThread.parent?.id : channelIdOrThreadId;
   const threadId = channelOrThread?.isThread() ? channelOrThread.id : null;
   const channel = channelOrThread?.isThread() ? channelOrThread.parent : channelOrThread;

--- a/backend/src/plugins/Automod/functions/runAutomod.ts
+++ b/backend/src/plugins/Automod/functions/runAutomod.ts
@@ -33,7 +33,15 @@ export async function runAutomod(pluginData: GuildPluginData<AutomodPluginType>,
 
   for (const [ruleName, rule] of Object.entries(config.rules)) {
     if (rule.enabled === false) continue;
-    if (!rule.affects_bots && (!user || user.bot) && !context.counterTrigger && !context.antiraid) continue;
+    if (
+      !rule.affects_bots &&
+      (!user || user.bot) &&
+      !context.counterTrigger &&
+      !context.antiraid &&
+      !context.threadChange?.deleted
+    ) {
+      continue;
+    }
     if (!rule.affects_self && userId && userId === pluginData.client.user?.id) continue;
 
     if (rule.cooldown && checkAndUpdateCooldown(pluginData, rule, context)) {

--- a/backend/src/plugins/Automod/triggers/availableTriggers.ts
+++ b/backend/src/plugins/Automod/triggers/availableTriggers.ts
@@ -26,6 +26,8 @@ import { NoteTrigger } from "./note";
 import { RoleAddedTrigger } from "./roleAdded";
 import { RoleRemovedTrigger } from "./roleRemoved";
 import { StickerSpamTrigger } from "./stickerSpam";
+import { ThreadCreateTrigger } from "./threadCreate";
+import { ThreadDeleteTrigger } from "./threadDelete";
 import { UnbanTrigger } from "./unban";
 import { UnmuteTrigger } from "./unmute";
 import { WarnTrigger } from "./warn";
@@ -64,6 +66,9 @@ export const availableTriggers: Record<string, AutomodTriggerBlueprint<any, any>
   unban: UnbanTrigger,
 
   antiraid_level: AntiraidLevelTrigger,
+
+  thread_create: ThreadCreateTrigger,
+  thread_delete: ThreadDeleteTrigger,
 };
 
 export const AvailableTriggers = t.type({
@@ -101,4 +106,7 @@ export const AvailableTriggers = t.type({
   unban: UnbanTrigger.configType,
 
   antiraid_level: AntiraidLevelTrigger.configType,
+
+  thread_create: ThreadCreateTrigger.configType,
+  thread_delete: ThreadDeleteTrigger.configType,
 });

--- a/backend/src/plugins/Automod/triggers/threadCreate.ts
+++ b/backend/src/plugins/Automod/triggers/threadCreate.ts
@@ -7,6 +7,8 @@ import { automodTrigger } from "../helpers";
 interface ThreadCreateResult {
   matchedThreadId: Snowflake;
   matchedThreadName: string;
+  matchedThreadParentId: Snowflake;
+  matchedThreadParentName: string;
   matchedThreadOwner: User | undefined;
 }
 
@@ -33,6 +35,8 @@ export const ThreadCreateTrigger = automodTrigger<ThreadCreateResult>()({
       extra: {
         matchedThreadId: thread.id,
         matchedThreadName: thread.name,
+        matchedThreadParentId: thread.parentId ?? "Unknown",
+        matchedThreadParentName: thread.parent?.name ?? "Unknown",
         matchedThreadOwner: context.user,
       },
     };
@@ -42,11 +46,12 @@ export const ThreadCreateTrigger = automodTrigger<ThreadCreateResult>()({
     const threadId = matchResult.extra.matchedThreadId;
     const threadName = matchResult.extra.matchedThreadName;
     const threadOwner = matchResult.extra.matchedThreadOwner;
+    const parentId = matchResult.extra.matchedThreadParentId;
+    const parentName = matchResult.extra.matchedThreadParentName;
+    const base = `Thread **#${threadName}** (\`${threadId}\`) has been created in the **#${parentName}** (\`${parentId}\`) channel`;
     if (threadOwner) {
-      return `Thread **#${Util.escapeBold(threadName)}** (\`${threadId}\`) has been created by **${
-        threadOwner.tag
-      }** (\`${threadOwner.id}\`)`;
+      return `${base} by **${Util.escapeBold(threadOwner.tag)}** (\`${threadOwner.id}\`)`;
     }
-    return `Thread **#${Util.escapeBold(threadName)}** (\`${threadId}\`) has been created`;
+    return base;
   },
 });

--- a/backend/src/plugins/Automod/triggers/threadCreate.ts
+++ b/backend/src/plugins/Automod/triggers/threadCreate.ts
@@ -1,0 +1,52 @@
+import { Snowflake } from "discord-api-types";
+import { ThreadChannel, User, Util } from "discord.js";
+import * as t from "io-ts";
+import { tNullable } from "../../../utils";
+import { automodTrigger } from "../helpers";
+
+interface ThreadCreateResult {
+  matchedThreadId: Snowflake;
+  matchedThreadName: string;
+  matchedThreadOwner: User | undefined;
+}
+
+export const ThreadCreateTrigger = automodTrigger<ThreadCreateResult>()({
+  configType: t.type({
+    parent: tNullable(t.union([t.string, t.array(t.string)])),
+  }),
+
+  defaultConfig: {},
+
+  async match({ context, triggerConfig }) {
+    if (!context.threadChange?.created) {
+      return;
+    }
+
+    const thread = context.threadChange.created;
+
+    if (triggerConfig.parent) {
+      const parentIds = Array.isArray(triggerConfig.parent) ? triggerConfig.parent : [triggerConfig.parent];
+      if (thread.parentId && !parentIds.includes(thread.parentId)) return;
+    }
+
+    return {
+      extra: {
+        matchedThreadId: thread.id,
+        matchedThreadName: thread.name,
+        matchedThreadOwner: context.user,
+      },
+    };
+  },
+
+  async renderMatchInformation({ matchResult }) {
+    const threadId = matchResult.extra.matchedThreadId;
+    const threadName = matchResult.extra.matchedThreadName;
+    const threadOwner = matchResult.extra.matchedThreadOwner;
+    if (threadOwner) {
+      return `Thread **#${Util.escapeBold(threadName)}** (\`${threadId}\`) has been created by **${
+        threadOwner.tag
+      }** (\`${threadOwner.id}\`)`;
+    }
+    return `Thread **#${Util.escapeBold(threadName)}** (\`${threadId}\`) has been created`;
+  },
+});

--- a/backend/src/plugins/Automod/triggers/threadCreate.ts
+++ b/backend/src/plugins/Automod/triggers/threadCreate.ts
@@ -1,7 +1,6 @@
 import { Snowflake } from "discord-api-types";
-import { ThreadChannel, User, Util } from "discord.js";
+import { User, Util } from "discord.js";
 import * as t from "io-ts";
-import { tNullable } from "../../../utils";
 import { automodTrigger } from "../helpers";
 
 interface ThreadCreateResult {
@@ -13,23 +12,15 @@ interface ThreadCreateResult {
 }
 
 export const ThreadCreateTrigger = automodTrigger<ThreadCreateResult>()({
-  configType: t.type({
-    parent: tNullable(t.union([t.string, t.array(t.string)])),
-  }),
-
+  configType: t.type({}),
   defaultConfig: {},
 
-  async match({ context, triggerConfig }) {
+  async match({ context }) {
     if (!context.threadChange?.created) {
       return;
     }
 
     const thread = context.threadChange.created;
-
-    if (triggerConfig.parent) {
-      const parentIds = Array.isArray(triggerConfig.parent) ? triggerConfig.parent : [triggerConfig.parent];
-      if (thread.parentId && !parentIds.includes(thread.parentId)) return;
-    }
 
     return {
       extra: {

--- a/backend/src/plugins/Automod/triggers/threadDelete.ts
+++ b/backend/src/plugins/Automod/triggers/threadDelete.ts
@@ -7,6 +7,8 @@ import { automodTrigger } from "../helpers";
 interface ThreadDeleteResult {
   matchedThreadId: Snowflake;
   matchedThreadName: string;
+  matchedThreadParentId: Snowflake;
+  matchedThreadParentName: string;
   matchedThreadOwner: User | undefined;
 }
 
@@ -33,6 +35,8 @@ export const ThreadDeleteTrigger = automodTrigger<ThreadDeleteResult>()({
       extra: {
         matchedThreadId: thread.id,
         matchedThreadName: thread.name,
+        matchedThreadParentId: thread.parentId ?? "Unknown",
+        matchedThreadParentName: thread.parent?.name ?? "Unknown",
         matchedThreadOwner: context.user,
       },
     };
@@ -40,13 +44,16 @@ export const ThreadDeleteTrigger = automodTrigger<ThreadDeleteResult>()({
 
   renderMatchInformation({ matchResult }) {
     const threadId = matchResult.extra.matchedThreadId;
-    const threadName = matchResult.extra.matchedThreadName;
     const threadOwner = matchResult.extra.matchedThreadOwner;
+    const threadName = matchResult.extra.matchedThreadName;
+    const parentId = matchResult.extra.matchedThreadParentId;
+    const parentName = matchResult.extra.matchedThreadParentName;
     if (threadOwner) {
-      return `Thread **${Util.escapeBold(threadName ?? "Unknown")}** (\`${threadId}\`) created by **${Util.escapeBold(
+      return `Thread **#${threadName ?? "Unknown"}** (\`${threadId}\`) created by **${Util.escapeBold(
         threadOwner.tag,
-      )}** (\`${threadOwner.id}\`) has been deleted`;
+      )}** (\`${threadOwner.id}\`) in the **#${parentName}** (\`${parentId}\`) channel has been deleted`;
     }
-    return `Thread **${Util.escapeBold(threadName ?? "Unknown")}** (\`${threadId}\`) has been deleted`;
+    return `Thread **#${threadName ??
+      "Unknown"}** (\`${threadId}\`) from the **#${parentName}** (\`${parentId}\`) channel has been deleted`;
   },
 });

--- a/backend/src/plugins/Automod/triggers/threadDelete.ts
+++ b/backend/src/plugins/Automod/triggers/threadDelete.ts
@@ -1,0 +1,52 @@
+import { Snowflake } from "discord-api-types";
+import { User, Util } from "discord.js";
+import * as t from "io-ts";
+import { tNullable } from "../../../utils";
+import { automodTrigger } from "../helpers";
+
+interface ThreadDeleteResult {
+  matchedThreadId: Snowflake;
+  matchedThreadName: string;
+  matchedThreadOwner: User | undefined;
+}
+
+export const ThreadDeleteTrigger = automodTrigger<ThreadDeleteResult>()({
+  configType: t.type({
+    parent: tNullable(t.union([t.string, t.array(t.string)])),
+  }),
+
+  defaultConfig: {},
+
+  async match({ context, triggerConfig }) {
+    if (!context.threadChange?.deleted) {
+      return;
+    }
+
+    const thread = context.threadChange.deleted;
+
+    if (triggerConfig.parent) {
+      const parentIds = Array.isArray(triggerConfig.parent) ? triggerConfig.parent : [triggerConfig.parent];
+      if (thread.parentId && !parentIds.includes(thread.parentId)) return;
+    }
+
+    return {
+      extra: {
+        matchedThreadId: thread.id,
+        matchedThreadName: thread.name,
+        matchedThreadOwner: context.user,
+      },
+    };
+  },
+
+  renderMatchInformation({ matchResult }) {
+    const threadId = matchResult.extra.matchedThreadId;
+    const threadName = matchResult.extra.matchedThreadName;
+    const threadOwner = matchResult.extra.matchedThreadOwner;
+    if (threadOwner) {
+      return `Thread **${Util.escapeBold(threadName ?? "Unknown")}** (\`${threadId}\`) created by **${Util.escapeBold(
+        threadOwner.tag,
+      )}** (\`${threadOwner.id}\`) has been deleted`;
+    }
+    return `Thread **${Util.escapeBold(threadName ?? "Unknown")}** (\`${threadId}\`) has been deleted`;
+  },
+});

--- a/backend/src/plugins/Automod/triggers/threadDelete.ts
+++ b/backend/src/plugins/Automod/triggers/threadDelete.ts
@@ -1,7 +1,6 @@
 import { Snowflake } from "discord-api-types";
 import { User, Util } from "discord.js";
 import * as t from "io-ts";
-import { tNullable } from "../../../utils";
 import { automodTrigger } from "../helpers";
 
 interface ThreadDeleteResult {
@@ -13,23 +12,15 @@ interface ThreadDeleteResult {
 }
 
 export const ThreadDeleteTrigger = automodTrigger<ThreadDeleteResult>()({
-  configType: t.type({
-    parent: tNullable(t.union([t.string, t.array(t.string)])),
-  }),
-
+  configType: t.type({}),
   defaultConfig: {},
 
-  async match({ context, triggerConfig }) {
+  async match({ context }) {
     if (!context.threadChange?.deleted) {
       return;
     }
 
     const thread = context.threadChange.deleted;
-
-    if (triggerConfig.parent) {
-      const parentIds = Array.isArray(triggerConfig.parent) ? triggerConfig.parent : [triggerConfig.parent];
-      if (thread.parentId && !parentIds.includes(thread.parentId)) return;
-    }
 
     return {
       extra: {
@@ -53,7 +44,8 @@ export const ThreadDeleteTrigger = automodTrigger<ThreadDeleteResult>()({
         threadOwner.tag,
       )}** (\`${threadOwner.id}\`) in the **#${parentName}** (\`${parentId}\`) channel has been deleted`;
     }
-    return `Thread **#${threadName ??
-      "Unknown"}** (\`${threadId}\`) from the **#${parentName}** (\`${parentId}\`) channel has been deleted`;
+    return `Thread **#${
+      threadName ?? "Unknown"
+    }** (\`${threadId}\`) from the **#${parentName}** (\`${parentId}\`) channel has been deleted`;
   },
 });

--- a/backend/src/plugins/Automod/types.ts
+++ b/backend/src/plugins/Automod/types.ts
@@ -1,4 +1,4 @@
-import { GuildMember, PartialGuildMember, ThreadChannel, User } from "discord.js";
+import { GuildMember, PartialGuildMember, TextChannel, ThreadChannel, User } from "discord.js";
 import * as t from "io-ts";
 import { BasePluginType, CooldownManager } from "knub";
 import { SavedMessage } from "../../data/entities/SavedMessage";
@@ -135,6 +135,7 @@ export interface AutomodContext {
     created?: ThreadChannel;
     deleted?: ThreadChannel;
   };
+  channel?: TextChannel | ThreadChannel;
 }
 
 export interface RecentAction {

--- a/backend/src/plugins/Automod/types.ts
+++ b/backend/src/plugins/Automod/types.ts
@@ -1,4 +1,4 @@
-import { GuildMember, PartialGuildMember, User } from "discord.js";
+import { GuildMember, PartialGuildMember, ThreadChannel, User } from "discord.js";
 import * as t from "io-ts";
 import { BasePluginType, CooldownManager } from "knub";
 import { SavedMessage } from "../../data/entities/SavedMessage";
@@ -130,6 +130,10 @@ export interface AutomodContext {
   };
   antiraid?: {
     level: string | null;
+  };
+  threadChange?: {
+    created?: ThreadChannel;
+    deleted?: ThreadChannel;
   };
 }
 


### PR DESCRIPTION
Example config:

![image](https://user-images.githubusercontent.com/42935195/131253978-dfe250c4-7616-49fe-9383-9ed0116e3d43.png)

```yml
plugins:
  automod: 
    config:
      rules:
        on_thread_create:
          triggers:
            - thread_create: {}
          actions:
            alert:
              channel: "705009450855039042"
              text: "{matchSummary}"
        on_thread_delete: 
          triggers:
            - thread_delete:
                parent: "705009450855039042"
          actions:
            alert:
              channel: "705009450855039042"
              text: "{matchSummary}"
```