### PR TITLE
DJS Temporary fix for school hub invites

### DIFF
--- a/backend/src/plugins/Utility/functions/getInviteInfoEmbed.ts
+++ b/backend/src/plugins/Utility/functions/getInviteInfoEmbed.ts
@@ -65,32 +65,33 @@ export async function getInviteInfoEmbed(
       `),
       inline: true,
     });
+    if (invite.channel) {
+      const channelName =
+        invite.channel.type === ChannelTypeStrings.VOICE ? `🔉 ${invite.channel.name}` : `#${invite.channel.name}`;
 
-    const channelName =
-      invite.channel.type === ChannelTypeStrings.VOICE ? `🔉 ${invite.channel.name}` : `#${invite.channel.name}`;
+      const channelCreatedAtTimestamp = snowflakeToTimestamp(invite.channel.id);
+      const channelCreatedAt = moment.utc(channelCreatedAtTimestamp, "x");
+      const channelAge = humanizeDuration(Date.now() - channelCreatedAtTimestamp, {
+        largest: 2,
+        round: true,
+      });
 
-    const channelCreatedAtTimestamp = snowflakeToTimestamp(invite.channel.id);
-    const channelCreatedAt = moment.utc(channelCreatedAtTimestamp, "x");
-    const channelAge = humanizeDuration(Date.now() - channelCreatedAtTimestamp, {
-      largest: 2,
-      round: true,
-    });
-
-    let channelInfo = trimLines(`
+      let channelInfo = trimLines(`
         Name: **${channelName}**
         ID: \`${invite.channel.id}\`
         Created: **${channelAge} ago**
     `);
 
-    if (invite.channel.type !== ChannelTypeStrings.VOICE) {
-      channelInfo += `\nMention: <#${invite.channel.id}>`;
-    }
+      if (invite.channel.type !== ChannelTypeStrings.VOICE) {
+        channelInfo += `\nMention: <#${invite.channel.id}>`;
+      }
 
-    embed.fields.push({
-      name: preEmbedPadding + "Channel information",
-      value: channelInfo,
-      inline: true,
-    });
+      embed.fields.push({
+        name: preEmbedPadding + "Channel information",
+        value: channelInfo,
+        inline: true,
+      });
+    }
 
     if (invite.inviter) {
       embed.fields.push({


### PR DESCRIPTION
For whatever reason, `invite.channel` is currently `null` for these invites, I assume it's a issue with DJS not parsing the type correctly.
For the time being (and for future-proofing) we should check if `channel` exists.

Invite Sample : `9A55gsSJDZ`


![image](https://user-images.githubusercontent.com/9076708/132090033-6007db98-7465-4eef-af28-7a4eeab03799.png)

![image](https://user-images.githubusercontent.com/9076708/132089998-6de1b0c0-78f4-4a54-9804-660a71e16614.png)


Issue reported by BanTheNons#8297 on discord (460478012794863637)