### PR TITLE
feat(mod-actions): require reason

### DIFF
--- a/backend/src/plugins/ModActions/ModActionsPlugin.ts
+++ b/backend/src/plugins/ModActions/ModActionsPlugin.ts
@@ -84,6 +84,7 @@ const defaultOptions = {
     can_deletecase: false,
     can_act_as_other: false,
     create_cases_for_manual_actions: true,
+    require_reason: ["warn"],
   },
   overrides: [
     {

--- a/backend/src/plugins/ModActions/commands/BanCmd.ts
+++ b/backend/src/plugins/ModActions/commands/BanCmd.ts
@@ -15,6 +15,7 @@ import { isBanned } from "../functions/isBanned";
 import { readContactMethodsFromArgs } from "../functions/readContactMethodsFromArgs";
 import { modActionsCmd } from "../types";
 import { LogsPlugin } from "../../Logs/LogsPlugin";
+import { TextChannel } from "discord.js";
 
 const opts = {
   mod: ct.member({ option: true }),
@@ -52,7 +53,13 @@ export const BanCmd = modActionsCmd({
     }
     const time = args["time"] ? args["time"] : null;
 
+    const config = pluginData.config.get();
     const reason = formatReasonWithAttachments(args.reason, [...msg.attachments.values()]);
+    if (!reason && config.require_reason.includes("ban")) {
+      sendErrorMessage(pluginData, msg.channel, "You must include a reason in your ban");
+      return;
+    }
+
     const memberToBan = await resolveMember(pluginData.client, pluginData.guild, user.id);
     // The moderator who did the action is the message author or, if used, the specified -mod
     let mod = msg.member;

--- a/backend/src/plugins/ModActions/commands/NoteCmd.ts
+++ b/backend/src/plugins/ModActions/commands/NoteCmd.ts
@@ -32,7 +32,12 @@ export const NoteCmd = modActionsCmd({
     }
 
     const userName = user.tag;
-    const reason = formatReasonWithAttachments(args.note, [...msg.attachments.values()]);
+    const config = pluginData.config.get();
+    const reason = formatReasonWithAttachments(args.reason, [...msg.attachments.values()]);
+    if (!reason && config.require_reason.includes("note")) {
+      sendErrorMessage(pluginData, msg.channel, "You must include a reason in your note");
+      return;
+    }
 
     const casesPlugin = pluginData.getPlugin(CasesPlugin);
     const createdCase = await casesPlugin.createCase({

--- a/backend/src/plugins/ModActions/commands/UnbanCmd.ts
+++ b/backend/src/plugins/ModActions/commands/UnbanCmd.ts
@@ -48,7 +48,12 @@ export const UnbanCmd = modActionsCmd({
     }
 
     pluginData.state.serverLogs.ignoreLog(LogType.MEMBER_UNBAN, user.id);
+    const config = pluginData.config.get();
     const reason = formatReasonWithAttachments(args.reason, [...msg.attachments.values()]);
+    if (!reason && config.require_reason.includes("unban")) {
+      sendErrorMessage(pluginData, msg.channel, "You must include a reason in your unban");
+      return;
+    }
 
     try {
       ignoreEvent(pluginData, IgnoredEventType.Unban, user.id);

--- a/backend/src/plugins/ModActions/commands/WarnCmd.ts
+++ b/backend/src/plugins/ModActions/commands/WarnCmd.ts
@@ -64,6 +64,10 @@ export const WarnCmd = modActionsCmd({
 
     const config = pluginData.config.get();
     const reason = formatReasonWithAttachments(args.reason, [...msg.attachments.values()]);
+    if (!reason && config.require_reason.includes("warn")) {
+      sendErrorMessage(pluginData, msg.channel, "You must include a reason in your warning");
+      return;
+    }
 
     const casesPlugin = pluginData.getPlugin(CasesPlugin);
     const priorWarnAmount = await casesPlugin.getCaseTypeAmountForUserId(memberToWarn.id, CaseTypes.Warn);

--- a/backend/src/plugins/ModActions/functions/actualKickMemberCmd.ts
+++ b/backend/src/plugins/ModActions/functions/actualKickMemberCmd.ts
@@ -67,7 +67,12 @@ export async function actualKickMemberCmd(
     return;
   }
 
+  const config = pluginData.config.get();
   const reason = formatReasonWithAttachments(args.reason, msg.attachments);
+  if (!reason && config.require_reason.includes("kick")) {
+    sendErrorMessage(pluginData, msg.channel, "You must include a reason in your kick");
+    return;
+  }
 
   const kickResult = await kickMember(pluginData, memberToKick, reason, {
     contactMethods,

--- a/backend/src/plugins/ModActions/functions/actualMuteUserCmd.ts
+++ b/backend/src/plugins/ModActions/functions/actualMuteUserCmd.ts
@@ -42,7 +42,12 @@ export async function actualMuteUserCmd(
   }
 
   const timeUntilUnmute = args.time && humanizeDuration(args.time);
+  const config = pluginData.config.get();
   const reason = args.reason ? formatReasonWithAttachments(args.reason, [...msg.attachments.values()]) : undefined;
+  if (!reason && config.require_reason.includes("mute")) {
+    sendErrorMessage(pluginData, msg.channel as TextChannel, "You must include a reason in your mute");
+    return;
+  }
 
   let muteResult: MuteResult;
   const mutesPlugin = pluginData.getPlugin(MutesPlugin);

--- a/backend/src/plugins/ModActions/functions/actualUnmuteUserCmd.ts
+++ b/backend/src/plugins/ModActions/functions/actualUnmuteUserCmd.ts
@@ -27,7 +27,12 @@ export async function actualUnmuteCmd(
     pp = msg.author;
   }
 
+  const config = pluginData.config.get();
   const reason = args.reason ? formatReasonWithAttachments(args.reason, [...msg.attachments.values()]) : undefined;
+  if (!reason && config.require_reason.includes("unmute")) {
+    sendErrorMessage(pluginData, msg.channel as TextChannel, "You must include a reason in your unmute");
+    return;
+  }
 
   const mutesPlugin = pluginData.getPlugin(MutesPlugin);
   const result = await mutesPlugin.unmuteUser(user.id, args.time, {

--- a/backend/src/plugins/ModActions/types.ts
+++ b/backend/src/plugins/ModActions/types.ts
@@ -46,6 +46,7 @@ export const ConfigSchema = t.type({
   can_deletecase: t.boolean,
   can_act_as_other: t.boolean,
   create_cases_for_manual_actions: t.boolean,
+  require_reason: t.array(t.string),
 });
 export type TConfigSchema = t.TypeOf<typeof ConfigSchema>;
 


### PR DESCRIPTION
As [highly requested](https://discord.com/channels/473085256233123841/534711895803035648/877739373607661578), I've implemented a `require_reason` configuration option for the mod actions plugin. You can configure it by the case type. I haven't gotten around testing it as yet, but if any of you are willing to, I'd appreciate it.