### PR TITLE
perf: rolescmd with -counts option

### DIFF
--- a/backend/src/plugins/Utility/commands/RolesCmd.ts
+++ b/backend/src/plugins/Utility/commands/RolesCmd.ts
@@ -34,17 +34,18 @@ export const RolesCmd = utilityCmd({
     if (args.counts) {
       await refreshMembersIfNeeded(guild);
 
-      // If the user requested role member counts as well, fetch them and sort the roles by their member count
-      const roleCounts: Map<string, number> = Array.from(guild.roles.cache.values()).reduce((map, role) => {
-        map.set(role.id, role.members.size);
-        return map;
-      }, new Map());
+      const roleCounts = new Map<string, number>();
+      for (const member of guild.members.cache.values()) {
+        for (const id of member.roles.cache.keys()) {
+          roleCounts.set(id, (roleCounts.get(id) ?? 0) + 1);
+        }
+      }
 
       // The "everyone" role always has all members in it
       roleCounts.set(guild.id, guild.memberCount);
 
       for (const role of roles) {
-        role._memberCount = roleCounts.has(role.id) ? roleCounts.get(role.id) : 0;
+        role._memberCount = roleCounts.get(role.id) ?? 0;
       }
 
       if (!sort) sort = "-memberCount";

--- a/backend/src/plugins/Utility/commands/RolesCmd.ts
+++ b/backend/src/plugins/Utility/commands/RolesCmd.ts
@@ -58,7 +58,7 @@ export const RolesCmd = utilityCmd({
     if (sort === "position" || sort === "order") {
       roles.sort(sorter("position", sortDir));
     } else if (sort === "memberCount" && args.counts) {
-      roles.sort((first, second) => (roleCounts!.get(second.id) ?? 0) - (roleCounts!.get(first.id) ?? 0));
+      roles.sort((first, second) => roleCounts!.get(second.id)! - roleCounts!.get(first.id)!);
     } else if (sort === "name") {
       roles.sort(sorter((r) => r.name.toLowerCase(), sortDir));
     } else {
@@ -80,15 +80,16 @@ export const RolesCmd = utilityCmd({
         return line;
       });
 
+      const codeBlock = "```py\n" + roleLines.join("\n") + "```";
       if (i === 0) {
         msg.channel.send(
           trimLines(`
           ${args.search ? "Total roles found" : "Total roles"}: ${roles.length}
-          \`\`\`py\n${roleLines.join("\n")}\`\`\`
+          ${codeBlock}
         `),
         );
       } else {
-        msg.channel.send("```py\n" + roleLines.join("\n") + "```");
+        msg.channel.send(codeBlock);
       }
     }
   },

--- a/backend/src/plugins/Utility/commands/RolesCmd.ts
+++ b/backend/src/plugins/Utility/commands/RolesCmd.ts
@@ -34,19 +34,17 @@ export const RolesCmd = utilityCmd({
     if (args.counts) {
       await refreshMembersIfNeeded(guild);
 
-      const roleCounts = new Map<string, number>();
       for (const member of guild.members.cache.values()) {
-        for (const id of member.roles.cache.keys()) {
-          roleCounts.set(id, (roleCounts.get(id) ?? 0) + 1);
+        for (const role of member.roles.cache.values()) {
+          // @ts-expect-error
+          role._memberCount ??= 0;
+          // @ts-expect-error
+          role._memberCount++;
         }
       }
 
-      // The "everyone" role always has all members in it
-      roleCounts.set(guild.id, guild.memberCount);
-
-      for (const role of roles) {
-        role._memberCount = roleCounts.get(role.id) ?? 0;
-      }
+      // The "@everyone" role always has all members in it
+      roles.find((r) => r.id === guild.id)!._memberCount = guild.memberCount;
 
       if (!sort) sort = "-memberCount";
       roles.sort((a, b) => {


### PR DESCRIPTION
Current setup:
![image](https://user-images.githubusercontent.com/42935195/134170123-ec870463-e55d-43dc-8d13-6bb61884e2bf.png)

With this pr:
![image](https://user-images.githubusercontent.com/42935195/134170136-b3e51842-87a8-463a-bbaa-b889bda2f778.png)

***

Why the current implementation is slow:
- It uses [`<Role>#members`](https://github.com/discordjs/discord.js/blob/stable/src/structures/Role.js#L139), which by itself uses [`<GuildMember>#roles#cache`](https://github.com/discordjs/discord.js/blob/stable/src/managers/GuildMemberRoleManager.js#L34)