### PR TITLE
perf: temp bans/mutes timeouts

### DIFF
--- a/backend/src/data/GuildMutes.ts
+++ b/backend/src/data/GuildMutes.ts
@@ -11,6 +11,14 @@ export class GuildMutes extends BaseGuildRepository {
     this.mutes = getRepository(Mute);
   }
 
+  async getAllTemporaryMutes(): Promise<Mute[]> {
+    return this.mutes
+      .createQueryBuilder("mutes")
+      .where("guild_id = :guild_id", { guild_id: this.guildId })
+      .andWhere("expires_at IS NOT NULL")
+      .getMany();
+  }
+
   async getExpiredMutes(): Promise<Mute[]> {
     return this.mutes
       .createQueryBuilder("mutes")

--- a/backend/src/data/GuildTempbans.ts
+++ b/backend/src/data/GuildTempbans.ts
@@ -11,9 +11,17 @@ export class GuildTempbans extends BaseGuildRepository {
     this.tempbans = getRepository(Tempban);
   }
 
+  async getAllTempbans(): Promise<Tempban[]> {
+    return this.tempbans
+      .createQueryBuilder("tempbans")
+      .where("guild_id = :guild_id", { guild_id: this.guildId })
+      .andWhere("expires_at IS NOT NULL")
+      .getMany();
+  }
+
   async getExpiredTempbans(): Promise<Tempban[]> {
     return this.tempbans
-      .createQueryBuilder("mutes")
+      .createQueryBuilder("tempbans")
       .where("guild_id = :guild_id", { guild_id: this.guildId })
       .andWhere("expires_at IS NOT NULL")
       .andWhere("expires_at <= NOW()")

--- a/backend/src/plugins/ModActions/commands/BanCmd.ts
+++ b/backend/src/plugins/ModActions/commands/BanCmd.ts
@@ -16,7 +16,8 @@ import { readContactMethodsFromArgs } from "../functions/readContactMethodsFromA
 import { modActionsCmd } from "../types";
 import { LogsPlugin } from "../../Logs/LogsPlugin";
 import moment from "moment";
-import { addTimer, removeTimer, removeTimerByUserId } from "../functions/outdatedTempbansLoop";
+import { clearTempBan } from "../functions/outdatedTempbansLoop";
+import { addTimer, removeTimer, removeTimerByUserId } from "src/utils/timers";
 
 const opts = {
   mod: ct.member({ option: true }),
@@ -96,13 +97,18 @@ export const BanCmd = modActionsCmd({
             if (existingTempban) {
               pluginData.state.tempbans.updateExpiryTime(user.id, time, mod.id);
               removeTimer(pluginData, existingTempban);
-              addTimer(pluginData, {
+              const newBanObj = {
                 ...existingTempban,
                 expires_at: moment().utc().add(time, "ms").format("YYYY-MM-DD HH:mm:ss"),
+              };
+              addTimer(pluginData, newBanObj, async () => {
+                await clearTempBan(pluginData, newBanObj);
               });
             } else {
               const tempban = await pluginData.state.tempbans.addTempban(user.id, time, mod.id);
-              addTimer(pluginData, tempban);
+              addTimer(pluginData, tempban, async () => {
+                await clearTempBan(pluginData, tempban);
+              });
             }
           } else if (existingTempban) {
             pluginData.state.tempbans.clear(user.id);

--- a/backend/src/plugins/ModActions/commands/UnbanCmd.ts
+++ b/backend/src/plugins/ModActions/commands/UnbanCmd.ts
@@ -10,7 +10,7 @@ import { formatReasonWithAttachments } from "../functions/formatReasonWithAttach
 import { ignoreEvent } from "../functions/ignoreEvent";
 import { IgnoredEventType, modActionsCmd } from "../types";
 import { LogsPlugin } from "../../Logs/LogsPlugin";
-import { removeTimerByUserId } from "../functions/outdatedTempbansLoop";
+import { removeTimerByUserId } from "src/utils/timers";
 
 const opts = {
   mod: ct.member({ option: true }),

--- a/backend/src/plugins/ModActions/commands/UnbanCmd.ts
+++ b/backend/src/plugins/ModActions/commands/UnbanCmd.ts
@@ -10,6 +10,7 @@ import { formatReasonWithAttachments } from "../functions/formatReasonWithAttach
 import { ignoreEvent } from "../functions/ignoreEvent";
 import { IgnoredEventType, modActionsCmd } from "../types";
 import { LogsPlugin } from "../../Logs/LogsPlugin";
+import { removeTimerByUserId } from "../functions/outdatedTempbansLoop";
 
 const opts = {
   mod: ct.member({ option: true }),
@@ -69,7 +70,7 @@ export const UnbanCmd = modActionsCmd({
     });
     // Delete the tempban, if one exists
     pluginData.state.tempbans.clear(user.id);
-
+    removeTimerByUserId(pluginData, user.id);
     // Confirm the action
     sendSuccessMessage(pluginData, msg.channel, `Member unbanned (Case #${createdCase.case_number})`);
 

--- a/backend/src/plugins/ModActions/functions/outdatedTempbansLoop.ts
+++ b/backend/src/plugins/ModActions/functions/outdatedTempbansLoop.ts
@@ -4,67 +4,123 @@ import { GuildPluginData } from "knub";
 import moment from "moment-timezone";
 import { LogType } from "src/data/LogType";
 import { logger } from "src/logger";
-import { userToTemplateSafeUser } from "../../../utils/templateSafeObjects";
 import { CaseTypes } from "../../../data/CaseTypes";
-import { resolveUser, SECONDS } from "../../../utils";
+import { MINUTES, resolveUser } from "../../../utils";
 import { CasesPlugin } from "../../Cases/CasesPlugin";
 import { IgnoredEventType, ModActionsPluginType } from "../types";
 import { formatReasonWithAttachments } from "./formatReasonWithAttachments";
 import { ignoreEvent } from "./ignoreEvent";
 import { isBanned } from "./isBanned";
 import { LogsPlugin } from "../../Logs/LogsPlugin";
+import { Tempban } from "src/data/entities/Tempban";
+import { ExpiringTimer } from "src/utils/timers";
 
-const TEMPBAN_LOOP_TIME = 60 * SECONDS;
+const LOAD_LESS_THAN_MIN_COUNT = 60 * MINUTES;
 
-export async function outdatedTempbansLoop(pluginData: GuildPluginData<ModActionsPluginType>) {
-  const outdatedTempbans = await pluginData.state.tempbans.getExpiredTempbans();
-
-  for (const tempban of outdatedTempbans) {
-    if (!(await isBanned(pluginData, tempban.user_id))) {
-      pluginData.state.tempbans.clear(tempban.user_id);
-      continue;
-    }
-
-    pluginData.state.serverLogs.ignoreLog(LogType.MEMBER_UNBAN, tempban.user_id);
-    const reason = formatReasonWithAttachments(
-      `Tempban timed out.
-      Tempbanned at: \`${tempban.created_at} UTC\``,
-      [],
-    );
-    try {
-      ignoreEvent(pluginData, IgnoredEventType.Unban, tempban.user_id);
-      await pluginData.guild.bans.remove(tempban.user_id as Snowflake, reason ?? undefined);
-    } catch (e) {
-      pluginData.getPlugin(LogsPlugin).logBotAlert({
-        body: `Encountered an error trying to automatically unban ${tempban.user_id} after tempban timeout`,
-      });
-      logger.warn(`Error automatically unbanning ${tempban.user_id} (tempban timeout): ${e}`);
-      return;
-    }
-
-    // Create case and delete tempban
-    const casesPlugin = pluginData.getPlugin(CasesPlugin);
-    const createdCase = await casesPlugin.createCase({
-      userId: tempban.user_id,
-      modId: tempban.mod_id,
-      type: CaseTypes.Unban,
-      reason,
-      ppId: undefined,
+export function addTimer(pluginData: GuildPluginData<ModActionsPluginType>, tempban: Tempban) {
+  const existingMute = pluginData.state.timers.find(
+    (tm) => tm.options.key === tempban.user_id && tm.options.guildId === tempban.guild_id && !tm.done,
+  ); // for future-proof when you do global events
+  if (!existingMute && tempban.expires_at) {
+    const exp = moment(tempban.expires_at!).toDate().getTime() - moment.utc().toDate().getTime();
+    const newTimer = new ExpiringTimer({
+      key: tempban.user_id,
+      guildId: tempban.guild_id,
+      plugin: "tempban",
+      expiry: exp,
+      callback: async () => {
+        await clearTempBan(pluginData, tempban);
+      },
     });
+    pluginData.state.timers.push(newTimer);
+  }
+}
+
+export function removeTimer(pluginData: GuildPluginData<ModActionsPluginType>, tempban: Tempban) {
+  const existingMute = pluginData.state.timers.findIndex(
+    (tm) => tm.options.key === tempban.user_id && tm.options.guildId === tempban.guild_id && !tm.done,
+  );
+  if (existingMute) {
+    const tm = pluginData.state.timers[existingMute];
+    tm.clear();
+    tm.done = true;
+    pluginData.state.timers.splice(existingMute, 1);
+  }
+}
+
+export function removeTimerByUserId(pluginData: GuildPluginData<ModActionsPluginType>, user_id: Snowflake) {
+  const existingMute = pluginData.state.timers.findIndex((tm) => tm.options.key === user_id && !tm.done);
+  if (existingMute) {
+    const tm = pluginData.state.timers[existingMute];
+    tm.clear();
+    tm.done = true;
+    pluginData.state.timers.splice(existingMute, 1);
+  }
+}
+
+export async function loadExpiringTimers(pluginData: GuildPluginData<ModActionsPluginType>) {
+  const now = moment.utc().toDate().getTime();
+  pluginData.state.timers = pluginData.state.timers.filter((tm) => !tm.done || !tm.timeout);
+  const tempbans = (await pluginData.state.tempbans.getAllTempbans()).filter((m) => m.expires_at);
+  const expiredBans = tempbans.filter((m) => now >= moment(m.expires_at!).toDate().getTime());
+  const expiringBans = tempbans.filter(
+    (m) => !expiredBans.find((exp) => exp.user_id === m.user_id && exp.guild_id === m.guild_id),
+  );
+
+  for (const tempban of expiringBans) {
+    const expires = moment(tempban.expires_at!).toDate().getTime();
+    if (expires <= now) continue; // exclude expired mutes, just in case
+    if (expires > now + LOAD_LESS_THAN_MIN_COUNT) continue; // exclude timers that are expiring in over 180 mins
+
+    addTimer(pluginData, tempban);
+  }
+
+  for (const tempban of expiredBans) {
+    await clearTempBan(pluginData, tempban);
+  }
+}
+
+export async function clearTempBan(pluginData: GuildPluginData<ModActionsPluginType>, tempban: Tempban) {
+  if (!(await isBanned(pluginData, tempban.user_id))) {
     pluginData.state.tempbans.clear(tempban.user_id);
+    return;
+  }
 
-    // Log the unban
-    const banTime = moment(tempban.created_at).diff(moment(tempban.expires_at));
-    pluginData.getPlugin(LogsPlugin).logMemberTimedUnban({
-      mod: await resolveUser(pluginData.client, tempban.mod_id),
-      userId: tempban.user_id,
-      caseNumber: createdCase.case_number,
-      reason,
-      banTime: humanizeDuration(banTime),
+  pluginData.state.serverLogs.ignoreLog(LogType.MEMBER_UNBAN, tempban.user_id);
+  const reason = formatReasonWithAttachments(
+    `Tempban timed out.
+  Tempbanned at: \`${tempban.created_at} UTC\``,
+    [],
+  );
+  try {
+    ignoreEvent(pluginData, IgnoredEventType.Unban, tempban.user_id);
+    await pluginData.guild.bans.remove(tempban.user_id as Snowflake, reason ?? undefined);
+  } catch (e) {
+    pluginData.getPlugin(LogsPlugin).logBotAlert({
+      body: `Encountered an error trying to automatically unban ${tempban.user_id} after tempban timeout`,
     });
+    logger.warn(`Error automatically unbanning ${tempban.user_id} (tempban timeout): ${e}`);
+    return;
   }
 
-  if (!pluginData.state.unloaded) {
-    pluginData.state.outdatedTempbansTimeout = setTimeout(() => outdatedTempbansLoop(pluginData), TEMPBAN_LOOP_TIME);
-  }
+  // Create case and delete tempban
+  const casesPlugin = pluginData.getPlugin(CasesPlugin);
+  const createdCase = await casesPlugin.createCase({
+    userId: tempban.user_id,
+    modId: tempban.mod_id,
+    type: CaseTypes.Unban,
+    reason,
+    ppId: undefined,
+  });
+  pluginData.state.tempbans.clear(tempban.user_id);
+
+  // Log the unban
+  const banTime = moment(tempban.created_at).diff(moment(tempban.expires_at));
+  pluginData.getPlugin(LogsPlugin).logMemberTimedUnban({
+    mod: await resolveUser(pluginData.client, tempban.mod_id),
+    userId: tempban.user_id,
+    caseNumber: createdCase.case_number,
+    reason,
+    banTime: humanizeDuration(banTime),
+  });
 }

--- a/backend/src/plugins/ModActions/types.ts
+++ b/backend/src/plugins/ModActions/types.ts
@@ -2,6 +2,7 @@ import { TextChannel } from "discord.js";
 import { EventEmitter } from "events";
 import * as t from "io-ts";
 import { BasePluginType, typedGuildCommand, typedGuildEventListener } from "knub";
+import { ExpiringTimer } from "src/utils/timers";
 import { Case } from "../../data/entities/Case";
 import { GuildCases } from "../../data/GuildCases";
 import { GuildLogs } from "../../data/GuildLogs";
@@ -70,9 +71,9 @@ export interface ModActionsPluginType extends BasePluginType {
     cases: GuildCases;
     tempbans: GuildTempbans;
     serverLogs: GuildLogs;
-
+    banClearIntervalId: Timeout;
+    timers: ExpiringTimer[];
     unloaded: boolean;
-    outdatedTempbansTimeout: Timeout | null;
     ignoredEvents: IIgnoredEvent[];
     massbanQueue: Queue;
 

--- a/backend/src/plugins/Mutes/functions/clearExpiredMutes.ts
+++ b/backend/src/plugins/Mutes/functions/clearExpiredMutes.ts
@@ -1,50 +1,102 @@
-import { Snowflake } from "discord.js";
 import { GuildPluginData } from "knub";
-import { memberToTemplateSafeMember } from "../../../utils/templateSafeObjects";
-import { LogType } from "../../../data/LogType";
-import { resolveMember, UnknownUser, verboseUserMention } from "../../../utils";
+import { MINUTES, resolveMember, UnknownUser, verboseUserMention } from "../../../utils";
 import { memberRolesLock } from "../../../utils/lockNameHelpers";
 import { MutesPluginType } from "../types";
 import { LogsPlugin } from "../../Logs/LogsPlugin";
+import { ExpiringTimer } from "src/utils/timers";
+import { Mute } from "src/data/entities/Mute";
+import moment from "moment";
 
-export async function clearExpiredMutes(pluginData: GuildPluginData<MutesPluginType>) {
-  const expiredMutes = await pluginData.state.mutes.getExpiredMutes();
-  for (const mute of expiredMutes) {
-    const member = await resolveMember(pluginData.client, pluginData.guild, mute.user_id, true);
+const LOAD_LESS_THAN_MIN_COUNT = 60 * MINUTES;
 
-    if (member) {
-      try {
-        const lock = await pluginData.locks.acquire(memberRolesLock(member));
-
-        const muteRole = pluginData.config.get().mute_role;
-        if (muteRole) {
-          await member.roles.remove(muteRole);
-        }
-        if (mute.roles_to_restore) {
-          const guildRoles = pluginData.guild.roles.cache;
-          const newRoles = [...member.roles.cache.keys()].filter((roleId) => roleId !== muteRole);
-          for (const toRestore of mute.roles_to_restore) {
-            if (guildRoles.has(toRestore) && toRestore !== muteRole && !newRoles.includes(toRestore)) {
-              newRoles.push(toRestore);
-            }
-          }
-          await member.roles.set(newRoles);
-        }
-
-        lock.unlock();
-      } catch {
-        pluginData.getPlugin(LogsPlugin).logBotAlert({
-          body: `Failed to remove mute role from ${verboseUserMention(member.user)}`,
-        });
-      }
-    }
-
-    await pluginData.state.mutes.clear(mute.user_id);
-
-    pluginData.getPlugin(LogsPlugin).logMemberMuteExpired({
-      member: member || new UnknownUser({ id: mute.user_id }),
+export function addTimer(pluginData: GuildPluginData<MutesPluginType>, mute: Mute) {
+  const existingMute = pluginData.state.timers.find(
+    (tm) => tm.options.key === mute.user_id && tm.options.guildId === mute.guild_id && !tm.done,
+  ); // for future-proof when you do global events
+  if (!existingMute && mute.expires_at) {
+    const exp = moment(mute.expires_at!).toDate().getTime() - moment.utc().toDate().getTime();
+    const newTimer = new ExpiringTimer({
+      key: mute.user_id,
+      guildId: mute.guild_id,
+      plugin: "mutes",
+      expiry: exp,
+      callback: async () => {
+        await clearExpiredMute(pluginData, mute);
+      },
     });
-
-    pluginData.state.events.emit("unmute", mute.user_id);
+    pluginData.state.timers.push(newTimer);
   }
+}
+
+export function removeTimer(pluginData: GuildPluginData<MutesPluginType>, mute: Mute) {
+  const existingMute = pluginData.state.timers.findIndex(
+    (tm) => tm.options.key === mute.user_id && tm.options.guildId === mute.guild_id && !tm.done,
+  );
+  if (existingMute) {
+    const tm = pluginData.state.timers[existingMute];
+    tm.clear();
+    tm.done = true;
+    pluginData.state.timers.splice(existingMute, 1);
+  }
+}
+
+export async function loadExpiringTimers(pluginData: GuildPluginData<MutesPluginType>) {
+  const now = moment.utc().toDate().getTime();
+  pluginData.state.timers = pluginData.state.timers.filter((tm) => !tm.done || !tm.timeout);
+  const mutes = (await pluginData.state.mutes.getAllTemporaryMutes()).filter((m) => m.expires_at);
+  const expiredMutes = mutes.filter((m) => now >= moment(m.expires_at!).toDate().getTime());
+  const expiringMutes = mutes.filter(
+    (m) => !expiredMutes.find((exp) => exp.user_id === m.user_id && exp.guild_id === m.guild_id),
+  );
+
+  for (const mute of expiringMutes) {
+    const expires = moment(mute.expires_at!).toDate().getTime();
+    if (expires <= now) continue; // exclude expired mutes, just in case
+    if (expires > now + LOAD_LESS_THAN_MIN_COUNT) continue; // exclude timers that are expiring in over 180 mins
+
+    addTimer(pluginData, mute);
+  }
+
+  for (const mute of expiredMutes) {
+    await clearExpiredMute(pluginData, mute);
+  }
+}
+
+export async function clearExpiredMute(pluginData: GuildPluginData<MutesPluginType>, mute: Mute) {
+  const member = await resolveMember(pluginData.client, pluginData.guild, mute.user_id, true);
+
+  if (member) {
+    try {
+      const lock = await pluginData.locks.acquire(memberRolesLock(member));
+
+      const muteRole = pluginData.config.get().mute_role;
+      if (muteRole) {
+        await member.roles.remove(muteRole);
+      }
+      if (mute.roles_to_restore) {
+        const guildRoles = pluginData.guild.roles.cache;
+        const newRoles = [...member.roles.cache.keys()].filter((roleId) => roleId !== muteRole);
+        for (const toRestore of mute.roles_to_restore) {
+          if (guildRoles.has(toRestore) && toRestore !== muteRole && !newRoles.includes(toRestore)) {
+            newRoles.push(toRestore);
+          }
+        }
+        await member.roles.set(newRoles);
+      }
+
+      lock.unlock();
+    } catch {
+      pluginData.getPlugin(LogsPlugin).logBotAlert({
+        body: `Failed to remove mute role from ${verboseUserMention(member.user)}`,
+      });
+    }
+  }
+
+  await pluginData.state.mutes.clear(mute.user_id);
+
+  pluginData.getPlugin(LogsPlugin).logMemberMuteExpired({
+    member: member || new UnknownUser({ id: mute.user_id }),
+  });
+
+  pluginData.state.events.emit("unmute", mute.user_id);
 }

--- a/backend/src/plugins/Mutes/types.ts
+++ b/backend/src/plugins/Mutes/types.ts
@@ -2,6 +2,7 @@ import { GuildMember } from "discord.js";
 import { EventEmitter } from "events";
 import * as t from "io-ts";
 import { BasePluginType, typedGuildCommand, typedGuildEventListener } from "knub";
+import { ExpiringTimer } from "src/utils/timers";
 import { Case } from "../../data/entities/Case";
 import { Mute } from "../../data/entities/Mute";
 import { GuildArchives } from "../../data/GuildArchives";
@@ -53,6 +54,8 @@ export interface MutesPluginType extends BasePluginType {
     archives: GuildArchives;
 
     muteClearIntervalId: Timeout;
+
+    timers: ExpiringTimer[];
 
     events: MutesEventEmitter;
   };

--- a/backend/src/utils/timers.ts
+++ b/backend/src/utils/timers.ts
@@ -1,4 +1,11 @@
 import { Snowflake } from "discord-api-types";
+import { GuildPluginData } from "knub";
+import moment from "moment";
+import { Mute } from "src/data/entities/Mute";
+import { Tempban } from "src/data/entities/Tempban";
+import { ModActionsPluginType } from "src/plugins/ModActions/types";
+import { MutesPluginType } from "src/plugins/Mutes/types";
+import { RemindersPluginType } from "src/plugins/Reminders/types";
 
 type TimerCallback = (key: string, expiry: number) => void;
 
@@ -36,5 +43,51 @@ export class ExpiringTimer {
   constructor(options: TimerOptions) {
     this.options = options;
     this.init();
+  }
+}
+
+export function addTimer(
+  pluginData: GuildPluginData<MutesPluginType | ModActionsPluginType>,
+  obj: Mute | Tempban,
+  callback: () => void,
+) {
+  const existing = pluginData.state.timers.find(
+    (tm) => tm.options.key === obj.user_id && tm.options.guildId === obj.guild_id && !tm.done,
+  ); // for future-proof when you do global events
+  if (!existing && obj.expires_at) {
+    const exp = moment(obj.expires_at!).toDate().getTime() - moment.utc().toDate().getTime();
+    const newTimer = new ExpiringTimer({
+      key: obj.user_id,
+      guildId: obj.guild_id,
+      plugin: "mutes",
+      expiry: exp,
+      callback,
+    });
+    pluginData.state.timers.push(newTimer);
+  }
+}
+
+export function removeTimer(pluginData: GuildPluginData<MutesPluginType | ModActionsPluginType>, obj: Mute | Tempban) {
+  const existing = pluginData.state.timers.findIndex(
+    (tm) => tm.options.key === obj.user_id && tm.options.guildId === obj.guild_id && !tm.done,
+  );
+  if (existing) {
+    const tm = pluginData.state.timers[existing];
+    tm.clear();
+    tm.done = true;
+    pluginData.state.timers.splice(existing, 1);
+  }
+}
+
+export function removeTimerByUserId(
+  pluginData: GuildPluginData<MutesPluginType | ModActionsPluginType>,
+  user_id: Snowflake,
+) {
+  const existing = pluginData.state.timers.findIndex((tm) => tm.options.key === user_id && !tm.done);
+  if (existing) {
+    const tm = pluginData.state.timers[existing];
+    tm.clear();
+    tm.done = true;
+    pluginData.state.timers.splice(existing, 1);
   }
 }

--- a/backend/src/utils/timers.ts
+++ b/backend/src/utils/timers.ts
@@ -1,0 +1,40 @@
+import { Snowflake } from "discord-api-types";
+
+type TimerCallback = (key: string, expiry: number) => void;
+
+type TimerOptions = {
+  key: Snowflake;
+  guildId?: Snowflake;
+  expiry: number;
+  plugin?: string;
+  callback: TimerCallback;
+};
+
+export class ExpiringTimer {
+  done: boolean = false;
+  options: TimerOptions;
+  timeout?: NodeJS.Timeout;
+  data?: any; // idk how to make this take generic <T> typings data
+  isValid() {
+    return !this.done;
+  }
+  private execute() {
+    if (!this.isValid()) return;
+    this.options.callback(this.options.key, this.options.expiry);
+    this.done = true;
+  }
+  init() {
+    if (this.timeout) this.clear();
+    this.timeout = setTimeout(() => this.execute(), this.options.expiry);
+  }
+  clear() {
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+      this.timeout = undefined;
+    }
+  }
+  constructor(options: TimerOptions) {
+    this.options = options;
+    this.init();
+  }
+}


### PR DESCRIPTION
Consider this a hotfix/guidance PR, not so much a fully-fledged PR.

Variable naming and general structure is not intended to be almeida-proof or generally pretty-looking, just trying to help with perf issues on the bot.

As discussed in #dev-discussion, effectively just sets timeouts for temporary mutes/bans expirations instead of polling the database every few seconds.

