### PR TITLE
Fixed mute error message double negative

### DIFF
--- a/backend/src/RecoverablePluginError.ts
+++ b/backend/src/RecoverablePluginError.ts
@@ -18,7 +18,7 @@ export const RECOVERABLE_PLUGIN_ERROR_MESSAGES = {
   [ERRORS.NO_USER_NOTIFICATION_CHANNEL]: "No user notify channel specified",
   [ERRORS.INVALID_USER_NOTIFICATION_CHANNEL]: "Invalid user notify channel specified",
   [ERRORS.INVALID_USER]: "Invalid user",
-  [ERRORS.INVALID_MUTE_ROLE_ID]: "Specified mute role is not invalid",
+  [ERRORS.INVALID_MUTE_ROLE_ID]: "Specified mute role is not valid",
   [ERRORS.MUTE_ROLE_ABOVE_ZEP]: "Specified mute role is above Zeppelin in the role hierarchy",
 };
 


### PR DESCRIPTION
I ran into this while testing. This error message gets thrown when the specified mute role is invalid, or when it is not valid. 
The previous error message of "not invalid" made no sense.