### PR TITLE
Fix: Remove reason requirement from slash ban command for consistency

### DIFF
--- a/backend/src/plugins/ModActions/commands/ban/BanSlashCmd.ts
+++ b/backend/src/plugins/ModActions/commands/ban/BanSlashCmd.ts
@@ -50,12 +50,6 @@ export const BanSlashCmd = modActionsSlashCmd({
     await interaction.deferReply({ ephemeral: true });
     const attachments = retrieveMultipleOptions(NUMBER_ATTACHMENTS_CASE_CREATION, options, "attachment");
 
-    if ((!options.reason || options.reason.trim() === "") && attachments.length < 1) {
-      pluginData.state.common.sendErrorMessage(interaction, "Text or attachment required", undefined, undefined, true);
-
-      return;
-    }
-
     let mod = interaction.member as GuildMember;
     const canActAsOther = await hasPermission(pluginData, "can_act_as_other", {
       channel: interaction.channel,


### PR DESCRIPTION
Removes the reason/attachment requirement validation from the slash ban command to match the existing behavior of the message ban command